### PR TITLE
Prime cache from options

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,18 @@ function watchify(opts) {
     var pending = false;
     var queuedCloses = {};
     var queuedDeps = {};
+    var first = true;
+
+    if (opts.cache) {
+        cache = opts.cache;
+        delete opts.cache;
+        first = false;
+    }
+
+    if (opts.pkgcache) {
+        pkgcache = opts.pkgcache;
+        delete opts.pkgcache;
+    }
 
     b.on('package', function (file, pkg) {
         pkgcache[file] = pkg;
@@ -51,7 +63,6 @@ function watchify(opts) {
 
 
     var bundle = b.bundle.bind(b);
-    var first = true;
     b.bundle = function (opts_, cb) {
         if (b._pending) return bundle(opts_, cb);
 


### PR DESCRIPTION
Pass `cache` and `pkgcache` in as options to share caches when building multiple client files with overlapping dependencies trees.  Dropped a clean build of 5 files depending on ~1600 modules from 30s down to 13s.

I'll integrate with grunt-watchify and or grunt-browserify to share the cache by default when you configure a target with multiple destination files.

Could be used to persist cache to disk to speed up subsequent runs when we're confident the files haven't changed.
