### PR TITLE
Add changingDeps re. substack/watchify#7

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ function watchify(opts) {
     var pending = false;
     var queuedCloses = {};
     var queuedDeps = {};
+    var changingDeps = {};
 
     b.on('package', function (file, pkg) {
         pkgcache[file] = pkg;
@@ -38,11 +39,13 @@ function watchify(opts) {
         watcher.on('change', function(path) {
             delete cache[dep.id];
             queuedCloses[dep.id] = watcher;
+            changingDeps[dep.id] = true
 
             // wait for the disk/editor to quiet down first:
             if (!pending) setTimeout(function () {
                 pending = false;
-                b.emit('update');
+                b.emit('update', Object.keys(changingDeps));
+                changingDeps = {};
             }, opts.delay || 300);
 
             pending = true;


### PR DESCRIPTION
From Issue #7 (now subsumed by this PR):

> It would be great to know, upon an update event is emitted, what files have changed in the latest update.
> 
> This will make it nicer when rebuilds occur to, on the user-side, output this handy information to the log or console and track what has been changed.

This PR seems like the simplest implementation - but just food for thought, if this is a feature you also think watchify should have. Cheers.
