### PR TITLE
Allow for browserify 3.x as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "bin": "bin/cmd.js",
   "dependencies": {
-    "browserify": ">=2.23.1 <3.0.0",
+    "browserify": ">=2.23.1 <4.0.0",
     "optimist": "~0.5.0",
     "through": "~2.2.1",
     "chokidar": "~0.6.3"


### PR DESCRIPTION
Addresses [#10](https://github.com/substack/watchify/issues/10), as browserify through 3.14.1 (current at the moment) works great as it seems.
