### PR TITLE
Copy queued deps

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var through = require('through');
+var copy = require('shallow-copy');
 var browserify = require('browserify');
 var fs = require('fs');
 
@@ -33,7 +34,7 @@ function watchify (opts) {
     });
     
     b.on('dep', function (dep) {
-        queuedDeps[dep.id] = dep;
+        queuedDeps[dep.id] = copy(dep);
     });
     
     function addDep (dep) {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "browserify": ">=3.21.1 <4.0.0",
     "optimist": "~0.5.0",
+    "shallow-copy": "0.0.1",
     "through": "~2.3.4"
   },
   "repository": {


### PR DESCRIPTION
JSON files were being modified after the `dep` event to prepend `module.exports=` to the file. This would result in watchify prepending `module.exports` to JSON files twice, which in turn would break certain bundles.

This fixes #18. Thanks!
