### PR TITLE
Don't queue undefined watchers for closing

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,9 @@ function watchify (opts) {
             delete fwatchers[id];
             delete fwatcherFiles[id];
         }
-        queuedCloses[id] = watchers[id];
+        if (watchers[id]) {
+            queuedCloses[id] = watchers[id];
+        }
         changingDeps[id] = true
         
         // wait for the disk/editor to quiet down first:


### PR DESCRIPTION
Sometimes (I'm not sure when this happens) a module gets `invalidate`'d before it is `appDep`'d. When it gets to the `close` handler `queuedCloses[depId].close();` throws. Checking that `watchers[id]` exists before putting it in `queuedDeps` seems to fix this without adverse effects.