### PR TITLE
Add option for watchers to allow you to share watchers between watchify instances

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ function watchify (opts) {
     var queuedDeps = {};
     var changingDeps = {};
     var first = true;
+    var watchers = {};
     
     if (opts.cache) {
         cache = opts.cache;
@@ -28,6 +29,11 @@ function watchify (opts) {
     if (opts.pkgcache) {
         pkgcache = opts.pkgcache;
         delete opts.pkgcache;
+    }
+
+    if (opts.watchers) {
+        watchers = opts.watchers;
+        delete opts.watchers;
     }
     
     b.on('package', function (file, pkg) {
@@ -60,14 +66,17 @@ function watchify (opts) {
         });
     });
     
-    var watchers = {};
     function addDep (dep) {
         if (watching[dep.id]) return;
         watching[dep.id] = true;
         cache[dep.id] = dep;
         
-        var watcher = chokidar.watch(dep.id, {persistent: true});
-        watchers[dep.id] = watcher;
+        var watcher = watchers[dep.id];
+        if (!watcher) {
+            watcher = watchers[dep.id] = chokidar.watch(dep.id, {persistent: true});
+            b.emit('watch', watcher, dep);
+        }
+
         watcher.on('error', b.emit.bind(b, 'error'));
         watcher.on('change', function () {
             invalidate(dep.id);


### PR DESCRIPTION
Thank you so much for this browserify plugin. In my project, we have an issue as the result of a large number of files sharing a large number of dependencies. These files are getting watched by each watchify instance. As a result of all these watchers being created a bunch of the same files, we are seeing this error everywhere:

```
(node) warning: possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit.
Trace
(node) warning: possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit.
Trace
    at StatWatcher.EventEmitter.addListener (events.js:160:15)
    at Object.fs.watchFile (fs.js:1163:8)
    at EventEmitter.FSWatcher._watch (/usr/local/lib/node_modules/modulename/node_modules/watchify/node_modules/chokidar/index.js:244:15)
    at EventEmitter.FSWatcher._handleFile (/usr/local/lib/node_modules/modulename/node_modules/watchify/node_modules/chokidar/index.js:270:8)
    at /usr/local/lib/node_modules/modulename/node_modules/watchify/node_modules/chokidar/index.js:356:15
    at Object.oncomplete (fs.js:107:15)
```

This is because node maintains a private event emitter hash for stats for all files the process is watching, so every shared dependency between watchify instances could be binding a listener to the same internal node watcher instance, despite being different chokidar watchers. Since we can't access the objects in node's private hash, we can't do anything about these alerts.

I'm not sure my solution is the best way to handle it, but I think it might sense to allow users to share watchers between watchify instances if they need to, if for no other reason than to preserve a bit of memory, but also to combat this error. A shared hash of chokidar hashes would better reflect whats going on "under the hood". Additionally, I think it would be a good idea to pair this change with the addition of a 'watch' event on the instance with the watcher and the dependency object so any wrapper plugins can manage these watchers themselves, if desired.

In order to make this work however, I had to check the watcher for the number of listeners bound to it before it could be closed in the ```invalidate``` function. Basically, I had to change invalidate to remove it's own listeners and then check if any listeners remain before closing the watcher.

I'm interested to hear other thoughts on this issue.