### PR TITLE
Fix issues with --standalone

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ function watchify (opts) {
         opts_.packageCache = pkgcache;
         
         // we only want to mess with the listeners if the bundle was created
-        // successfully, e.g. on the 'close' event.
+        // successfully, e.g. on the 'end' event.
         var outStream = bundle(opts_, cb);
         outStream.on('error', function (err) {
             var updated = false;
@@ -126,8 +126,8 @@ function watchify (opts) {
                 })();
             }
         });
-        outStream.on('close', close);
-        function close () {
+        outStream.on('end', end);
+        function end () {
             first = false;
             var depId;
             for (depId in queuedCloses) {


### PR DESCRIPTION
When browserify is invoked with --standalone, the bundle() will return
a through2 stream. This stream does not emit the 'close' event. The 'end'
event comes through though.

Switching watchify to use the 'end' event seems to work with and without
--standalone option.

---

This would fix issue #36. Although I admit I'm not completely familiar with the difference between the two events. I gave it a quick test and it seemed to work, but not sure if there are cases when the `end` event misbehaves.
