### PR TITLE
Fix notation that breaks Node 0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "optimist": "~0.5.0",
     "shallow-copy": "0.0.1",
     "through": "~2.3.4",
-    "chokidar": "^0.8.1"
+    "chokidar": "~0.8.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Switch ^ for ~
