### PR TITLE
Fix for when calling watchify w/o args

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,14 @@ module.exports = watchify;
 watchify.browserify = browserify;
 
 function watchify (files, opts) {
-    if (!opts) opts = {};
-    var b = typeof files.bundle === 'function' ? files : browserify(files, opts);
+    var b;
+    if (!opts) {
+        opts = files || {};
+        files = undefined;
+        b = typeof opts.bundle === 'function' ? opts : browserify(opts);
+    } else {
+        b = typeof files.bundle === 'function' ? files : browserify(files, opts);
+    }
     var cache = {};
     var pkgcache = {};
     var pending = false;


### PR DESCRIPTION
Broke in https://github.com/substack/watchify/commit/087cae474155f27210440d58d2873646192e0d9d
