### PR TITLE
Add --ignore-watch option, pass --delay option from cmd.js, documentation.

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -9,6 +9,11 @@ var fromArgs = require('browserify/bin/args');
 var w, outfile, verbose, dotfile;
 var prevErrs = [], first = true;
 
+var alias = {
+    'ignore-watch': 'ignoreWatch',
+    'delay': 'delay' // to forward delay var to watchify 
+};
+
 function showError (err) {
     if (prevErrs.indexOf(String(err)) < 0) {
         console.error(err + '');
@@ -17,7 +22,11 @@ function showError (err) {
 }
 
 (function retry () {
-    w = watchify(fromArgs(process.argv.slice(2)));
+    var opts = fromArgs(process.argv.slice(2));
+    Object.keys(opts.argv).forEach(function(key) {
+        if (alias[key]) opts[alias[key]] = opts.argv[key];
+    });
+    w = watchify(opts);
     outfile = w.argv.o || w.argv.outfile;
     verbose = w.argv.v || w.argv.verbose;
     

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "optimist": "~0.5.0",
     "shallow-copy": "0.0.1",
     "through": "~2.3.4",
-    "chokidar": "^0.8.1"
+    "chokidar": "^0.8.1",
+    "minimatch": "~0.3.0"
   },
   "scripts": {
     "test": "tape test/*.js"

--- a/readme.markdown
+++ b/readme.markdown
@@ -1,10 +1,10 @@
 # watchify
 
-watch mode for browserify builds
+Watch mode for browserify builds
 
 [![build status](https://secure.travis-ci.org/substack/watchify.png)](http://travis-ci.org/substack/watchify)
 
-Update any source file and your browserify bundle will be recompiled on the
+Update any source file and your browserify bundle will be incrementally recompiled on the
 spot.
 
 # example
@@ -33,7 +33,26 @@ $ watchify browser.js -d -o static/bundle.js -v
 
 # usage
 
-All the bundle options are the same as the browserify command except for `-v`.
+Watchify supports all the same options as the browserify command with the following additions:
+
+```
+  --ignore-watch=GLOB  
+
+  Don't attach file watchers to the following glob. 
+  Useful for e.g. ignoring `node_modules` (`--ignore-watch=node_modules/**`)
+  
+  --delay=ms           [default: 600]
+
+  The number of ms to wait before emitting an 'update' event on a file change.
+  Set lower to get more immediate updates at the risk of causing multiple bundle changes per save.
+  It's usually not worth =changing this.
+
+  --verbose, -v
+
+  Verbose mode. Will print to stderr on a rebuild.
+```
+
+The above options (excepting `verbose`) exist as options to the `watchify()` constructor in camelCase.
 
 # methods
 

--- a/test/ignore.js
+++ b/test/ignore.js
@@ -1,0 +1,71 @@
+var test = require('tape');
+var fs = require('fs');
+var path = require('path');
+var mkdirp = require('mkdirp');
+var spawn = require('child_process').spawn;
+var split = require('split');
+
+var cmd = path.resolve(__dirname, '../bin/cmd.js');
+var os = require('os');
+var tmpdir = path.join((os.tmpdir || os.tmpDir)(), 'watchify-' + Math.random());
+
+var files = {
+    main: path.join(tmpdir, 'main.js'),
+    dep: path.join(tmpdir, 'dep.js'),
+    bundle: path.join(tmpdir, 'bundle.js')
+};
+
+mkdirp.sync(tmpdir);
+fs.writeFileSync(files.main, 'require("./dep");\nconsole.log(555);');
+fs.writeFileSync(files.dep, 'console.log(222);');
+
+test('ignore', function (t) {
+    t.plan(8);
+    var ps = spawn(cmd, [ files.main, '-o', files.bundle, '-v', '--ignore-watch=de*' ]);
+    var lineNum = 0;
+    ps.stderr.pipe(split()).on('data', function onBundle(line) {
+        lineNum ++;
+        if (lineNum === 1) {
+            run(files.bundle, function (err, output) {
+                t.ifError(err);
+                t.equal(output, '222\n555\n');
+                fs.writeFile(files.dep, 'console.log(333)');
+                // since the bundle won't run
+                setTimeout(function(){
+                    t.equal(lineNum, 1);
+                    onBundle();
+                }, 1000); 
+            });
+        }
+        else if (lineNum === 2) {
+            run(files.bundle, function (err, output) {
+                t.ifError(err);
+                t.equal(output, '222\n555\n');
+                fs.writeFile(files.main, 'require("./dep");\nconsole.log(444);');
+            });
+        }
+        else if (lineNum === 3) {
+            run(files.bundle, function (err, output) {
+                t.ifError(err);
+                t.equal(output, '333\n444\n');
+
+                // Ensure no other events fire
+                setTimeout(function() {
+                    t.equal(lineNum, 3);
+                    ps.kill();
+                }, 500);
+            });
+        }
+    });
+});
+
+function run (file, cb) {
+    var ps = spawn(process.execPath, [ file ]);
+    var data = [];
+    ps.stdout.on('data', function (buf) { data.push(buf) });
+    ps.stdout.on('end', function () {
+        cb(null, Buffer.concat(data).toString('utf8'));
+    });
+    ps.on('error', cb);
+    return ps;
+}

--- a/test/many.js
+++ b/test/many.js
@@ -57,8 +57,6 @@ fs.writeFileSync(files.lines, 'beep\nboop');
 test('many edits', function (t) {
     t.plan(expected.length * 2 + edits.length);
     var ps = spawn(cmd, [ files.main, '-t', 'brfs', '-o', files.bundle, '-v' ]);
-    ps.stdout.pipe(process.stdout);
-    ps.stderr.pipe(process.stdout);
     var lineNum = 0;
     ps.stderr.pipe(split()).on('data', function (line) {
         if (line.length === 0) return;

--- a/test/many_immediate.js
+++ b/test/many_immediate.js
@@ -57,8 +57,6 @@ fs.writeFileSync(files.lines, 'beep\nboop');
 test('many immediate', function (t) {
     t.plan(expected.length * 2 + edits.length);
     var ps = spawn(cmd, [ files.main, '-t', 'brfs', '-o', files.bundle, '-v' ]);
-    ps.stdout.pipe(process.stdout);
-    ps.stderr.pipe(process.stdout);
     var lineNum = 0;
     ps.stderr.pipe(split()).on('data', function (line) {
         if (line.length === 0) return;


### PR DESCRIPTION
`--ignore-watch=glob` (or `{ignoreWatch: String|RegExp}`) allows the user to cut down on used CPU / open file descriptors by ignoring watching of certain files. Useful for ignoring files you know should not change, like `node_modules`.

Fixes #11, and does not clobber the `ignore` option like #31.