### PR TITLE
Failing testcase for errors generated by transforms (#64)

### DIFF
--- a/test/errors.js
+++ b/test/errors.js
@@ -1,0 +1,57 @@
+var test = require('tape');
+var watchify = require('../');
+var browserify = require('browserify');
+var vm = require('vm');
+
+var fs = require('fs');
+var path = require('path');
+var mkdirp = require('mkdirp');
+var split = require('split');
+
+var os = require('os');
+var tmpdir = path.join((os.tmpdir || os.tmpDir)(), 'watchify-' + Math.random());
+
+var file = path.join(tmpdir, 'main.js');
+
+mkdirp.sync(tmpdir);
+fs.writeFileSync(file, 'console.log(555)');
+
+test('errors', function (t) {
+    t.plan(5);
+    var w = watchify(browserify(file));
+    w.bundle(function (err, src) {
+        t.ifError(err);
+        t.equal(run(src), '555\n');
+        breakTheBuild();
+    });
+    function breakTheBuild() {
+        setTimeout(function() {
+            fs.writeFileSync(file, 'console.log(');
+        }, 1000);
+        w.once('update', function () {
+            w.bundle(function (err, src) {
+                t.ok(err instanceof Error, 'should be error');
+                fixTheBuild();
+            });
+        });
+    }
+    function fixTheBuild() {
+        setTimeout(function() {
+            fs.writeFileSync(file, 'console.log(333)');
+        }, 1000);
+        w.once('update', function () {
+            w.bundle(function (err, src) {
+                t.ifError(err);
+                t.equal(run(src), '333\n');
+                w.close();
+            });
+        });
+    }
+});
+
+function run (src) {
+    var output = '';
+    function log (msg) { output += msg + '\n' }
+    vm.runInNewContext(src, { console: { log: log } });
+    return output;
+}

--- a/test/errors_transform.js
+++ b/test/errors_transform.js
@@ -1,0 +1,82 @@
+var test = require('tape');
+var watchify = require('../');
+var browserify = require('browserify');
+var vm = require('vm');
+
+var fs = require('fs');
+var path = require('path');
+var mkdirp = require('mkdirp');
+var through = require('through');
+
+var os = require('os');
+var tmpdir = path.join((os.tmpdir || os.tmpDir)(), 'watchify-' + Math.random());
+
+var main = path.join(tmpdir, 'main.js');
+var file = path.join(tmpdir, 'dep.jsnum');
+
+mkdirp.sync(tmpdir);
+fs.writeFileSync(main, 'require("./dep.jsnum")');
+fs.writeFileSync(file, 'console.log(555)');
+
+function someTransform(file) {
+    if (!/\.jsnum$/.test(file)) {
+        return through();
+    }
+    function write(chunk) {
+        if (/\d/.test(chunk)) {
+            this.queue(chunk);
+        } else {
+            this.emit('error', new Error('No number in this chunk'));
+        }
+    }
+    return through(write);
+}
+
+test('errors in transform', function (t) {
+    t.plan(6);
+    var b = browserify(main);
+    b.transform(someTransform);
+    var w = watchify(b);
+    w.bundle(function (err, src) {
+        t.ifError(err);
+        t.equal(run(src), '555\n');
+        breakTheBuild();
+    });
+    function breakTheBuild() {
+        setTimeout(function() {
+            fs.writeFileSync(file, 'console.log()');
+        }, 1000);
+        w.once('update', function () {
+            w.bundle(function (err, src) {
+                t.ok(err instanceof Error, 'should be error');
+                t.equal(err.message, 'No number in this chunk');
+                fixTheBuild();
+            });
+        });
+    }
+    function fixTheBuild() {
+        setTimeout(function() {
+            fs.writeFileSync(file, 'console.log(333)');
+        }, 1000);
+        var safety = setTimeout(function() {
+            t.fail("gave up waiting");
+            w.close();
+            t.end();
+        }, 5000);
+        w.once('update', function () {
+            clearTimeout(safety);
+            w.bundle(function (err, src) {
+                t.ifError(err);
+                t.equal(run(src), '333\n');
+                w.close();
+            });
+        });
+    }
+});
+
+function run (src) {
+    var output = '';
+    function log (msg) { output += msg + '\n' }
+    vm.runInNewContext(src, { console: { log: log } });
+    return output;
+}


### PR DESCRIPTION
I've managed to produce a failing testcase for the issue described in #64

As discussed in the issue there, 0.8.1 is the last known good build - git bisect confirms that bcda5eb30be1183dd677d74585ed729ce2a486e4 is the first commit where the test begins to fail.

However, I think this is a red herring, and that the real issue is the removal of `queuedCloses` in ad8e483ef44cd4db28472d8c5b8640c82c291b67.

The scenario goes something like this:
1. `file` event for File A
2. File A is now watched
3. File A is modified, chokidar detects this
4. invalidate() is called for File A
5. The watch on File A is removed
6. The transform step fails due to the error, and no new `file` event is raised

Fixing the error has no effect now, as there's no active watch on the file.

I think there's two possible fixes here:
1. Have browserify emit the `file` event even if the transform fails (or before the transform runs?)
2. Only remove the watchers after the next successful bundle is completed

Hopefully @tmpvar and/or @substack can advise? I'm happy to put together the PR for either of those, or any other suggested fix.
