### PR TITLE
Emit delta, not time, in log event

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ function watchify (b, opts) {
             b.emit('time', delta);
             b.emit('bytes', bytes);
             b.emit('log', bytes + ' bytes written ('
-                + (time / 1000).toFixed(2) + ' seconds)'
+                + (delta / 1000).toFixed(2) + ' seconds)'
             );
             this.push(null);
         }


### PR DESCRIPTION
I believe this was a typo - we don't want to emit the the actual time.
