### PR TITLE
Fixed tests to pass for commands using transforms

### DIFF
--- a/test/bin_brfs.js
+++ b/test/bin_brfs.js
@@ -25,7 +25,7 @@ fs.writeFileSync(files.lines, 'beep\nboop');
 
 test('bin brfs', function (t) {
     t.plan(4);
-    var ps = spawn(cmd, [ files.main, '-t', 'brfs', '-o', files.bundle, '-v' ]);
+    var ps = spawn(cmd, [ files.main, '-t', path.resolve(__dirname, '../node_modules/brfs'), '-o', files.bundle, '-v' ]);
     var lineNum = 0;
     ps.stderr.pipe(split()).on('data', function (line) {
         lineNum ++;

--- a/test/many.js
+++ b/test/many.js
@@ -56,7 +56,7 @@ fs.writeFileSync(files.lines, 'beep\nboop');
 
 test('many edits', function (t) {
     t.plan(expected.length * 2 + edits.length);
-    var ps = spawn(cmd, [ files.main, '-t', 'brfs', '-o', files.bundle, '-v' ]);
+    var ps = spawn(cmd, [ files.main, '-t', path.resolve(__dirname, '../node_modules/brfs'), '-o', files.bundle, '-v' ]);
     ps.stdout.pipe(process.stdout);
     ps.stderr.pipe(process.stdout);
     var lineNum = 0;

--- a/test/many_immediate.js
+++ b/test/many_immediate.js
@@ -56,7 +56,7 @@ fs.writeFileSync(files.lines, 'beep\nboop');
 
 test('many immediate', function (t) {
     t.plan(expected.length * 2 + edits.length);
-    var ps = spawn(cmd, [ files.main, '-t', 'brfs', '-o', files.bundle, '-v' ]);
+    var ps = spawn(cmd, [ files.main, '-t', path.resolve(__dirname, '../node_modules/brfs'), '-o', files.bundle, '-v' ]);
     ps.stdout.pipe(process.stdout);
     ps.stderr.pipe(process.stdout);
     var lineNum = 0;


### PR DESCRIPTION
This fixes issue #73.
Realistically, this only fixes the symptoms of the issue, not the problem. The problem is probably upstream in Browserify, as I [detailed in that issue](/substack/watchify/issues/73#issuecomment-51434087).
