### PR TITLE
Expose pending flag.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,10 @@ function watchify (b, opts) {
     var changingDeps = {};
     var pending = false;
     
+    b.isPending = function () {
+        return pending;
+    }
+    
     b.on('dep', function (dep) {
         if (typeof dep.id === 'string') {
             cache[dep.id] = dep;


### PR DESCRIPTION
There is a 600ms delay between a save and the bundle being upto date.

If I refresh my browser within that 600ms window I will get a stale bundle and this can lead to confusion.

Ideally I want my "smart" static browserify http server to check for `isPending()` and refuse to send the javascript file until an `"update"` event has fired. 

This means it will slow down serving the javascript file by upto 600 milliseconds but the file will never be stale.

For my use case being able to ensure that I never sent stale files to a browser is important.