### PR TITLE
prevent inifinte rebundle (do not watch dirs)

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,7 @@ function watchify (b, opts) {
     });
     
     function watchFile (file) {
+        if (fs.lstatSync (file).isDirectory ()) return;
         if (!fwatchers[file]) fwatchers[file] = [];
         if (!fwatcherFiles[file]) fwatcherFiles[file] = [];
         if (fwatcherFiles[file].indexOf(file) >= 0) return;


### PR DESCRIPTION
do not watch directories since it (for some reason)
makes wachify to rebundle again and again with no
reason, even if no file has changed.

after some debugging, it seems the rebundle trigger
is the act of invalidating the root project's directory
itself.
we wouldn't care so much on repetitive rebundling
if the rebundle worked well, but the result of these
rebundles never affected the original output, so the
watchify didn't produce an update bundle anymore until
its process has been restarted.

once this patch has been applied, everything started
to work nicely.
