### PR TITLE
Preventing exception when explicit cache param is not provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ function watchify (b, opts) {
     }
     
     function invalidate (id) {
-        delete cache[id];
+        if (cache) delete cache[id];
         if (fwatchers[id]) {
             fwatchers[id].forEach(function (w) {
                 w.close();


### PR DESCRIPTION
#75 is causing issues for users that used watchify before the docs pointed out the required cache params.

With this simple change I could get beefy back working, which seems way simpler than refactoring how beefy handles params https://github.com/chrisdickinson/beefy/issues/51 
