### PR TITLE
Print out compile errors in the browser

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -24,6 +24,9 @@ function bundle () {
     var wb = w.bundle();
     wb.on('error', function (err) {
         console.error(String(err));
+        fs.writeFile(outfile, 'console.error('+JSON.stringify(String(err))+')', function(err) {
+            if (err) console.error(err);
+        })
     });
     wb.pipe(fs.createWriteStream(dotfile));
     


### PR DESCRIPTION
This will make the bundle file print to `console.error` in the browser in case there was an error compiling
