### PR TITLE
Bump chokidar version to fix #81 and fix #82

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bin": "bin/cmd.js",
   "dependencies": {
     "browserify": "^5.5.0",
-    "chokidar": "~0.8.2",
+    "chokidar": "~0.9.0",
     "through2": "~0.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Prior to chokidar 0.9, removing a watcher (for instance `w.close()` in `watchify#invalidate()`) will remove **all** watcher from anywhere (global `fs.unwatchFile()`). 

See [fix: Closing a chokidar instance prevent other instances to watch a file](https://github.com/paulmillr/chokidar/pull/150)

Maybe this fix is related to #81 and #82
