### PR TITLE
bump browserify to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "bin": "bin/cmd.js",
   "dependencies": {
-    "browserify": "^5.5.0",
+    "browserify": "^6.1.0",
     "chokidar": "~0.8.2",
     "through2": "~0.5.1"
   },


### PR DESCRIPTION
Streams are broken in 5.5.0 for some reason. Let’s use v6.
