### PR TITLE
Remove rename (causing EPERM error on Windows)

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -28,20 +28,17 @@ function bundle () {
             if (err) console.error(err);
         })
     });
-    wb.pipe(fs.createWriteStream(dotfile));
+    wb.pipe(fs.createWriteStream(outfile));
     
     var bytes, time;
     w.on('bytes', function (b) { bytes = b });
     w.on('time', function (t) { time = t });
     
     wb.on('end', function () {
-        fs.rename(dotfile, outfile, function (err) {
-            if (err) return console.error(err);
-            if (verbose) {
-                console.error(bytes + ' bytes written to ' + outfile
-                    + ' (' + (time / 1000).toFixed(2) + ' seconds)'
-                );
-            }
-        });
+        if (verbose) {
+            console.error(bytes + ' bytes written to ' + outfile
+                + ' (' + (time / 1000).toFixed(2) + ' seconds)'
+            );
+        }
     });
 }


### PR DESCRIPTION
Fixes #83 by writing directly to the output file rather than writing to a temp file and renaming it.
