### PR TITLE
Set higher max listeners limit on event emitter instances

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,6 +81,7 @@ function watchify (b, opts) {
         if (fwatcherFiles[file].indexOf(file) >= 0) return;
         
         var w = chokidar.watch(file, {persistent: true});
+        w.setMaxListeners(0);
         w.on('error', b.emit.bind(b, 'error'));
         w.on('change', function () {
             invalidate(file);
@@ -95,6 +96,7 @@ function watchify (b, opts) {
         if (fwatcherFiles[mfile].indexOf(file) >= 0) return;
 
         var w = chokidar.watch(file, {persistent: true});
+        w.setMaxListeners(0);
         w.on('error', b.emit.bind(b, 'error'));
         w.on('change', function () {
             invalidate(mfile);


### PR DESCRIPTION
This fixes the errors mentioned in this pull #32.

At Tumblr we're watching many separate bundles at once, which is where these errors come up.

This may not address all of the issues noted in #32, but it does raise the listener limit and suppress the alert messages.

The same method is already used in the command line API, https://github.com/substack/watchify/blob/master/bin/cmd.js#L9

```
(node) warning: possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit.
Trace
(node) warning: possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit.
Trace
    at StatWatcher.EventEmitter.addListener (events.js:160:15)
    at Object.fs.watchFile (fs.js:1163:8)
    at EventEmitter.FSWatcher._watch (/usr/local/lib/node_modules/modulename/node_modules/watchify/node_modules/chokidar/index.js:244:15)
    at EventEmitter.FSWatcher._handleFile (/usr/local/lib/node_modules/modulename/node_modules/watchify/node_modules/chokidar/index.js:270:8)
    at /usr/local/lib/node_modules/modulename/node_modules/watchify/node_modules/chokidar/index.js:356:15
    at Object.oncomplete (fs.js:107:15)
```
