### PR TITLE
Resolve realPath prior to creating watcher (fixes #109)

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,6 +88,10 @@ function watchify (b, opts) {
     }
     
     function watchFile_ (file) {
+        var realPath = fs.realpathSync(file);
+        if(realPath.split(path.sep)[1] != 'private') {
+          file = realPath;
+        }
         if (!fwatchers[file]) fwatchers[file] = [];
         if (!fwatcherFiles[file]) fwatcherFiles[file] = [];
         if (fwatcherFiles[file].indexOf(file) >= 0) return;
@@ -95,6 +99,14 @@ function watchify (b, opts) {
     }
     
     function watchDepFile(mfile, file) {
+      var realPath = fs.realpathSync(file);
+      var realPathM = fs.realpathSync(mfile);
+        if(realPath.split(path.sep)[1] != 'private') {
+          file = fs.realpathSync(file);
+        }
+        if(realPathM.split(path.sep)[1] != 'private') {
+          mfile = fs.realpathSync(mfile);
+        }
         if (!fwatchers[mfile]) fwatchers[mfile] = [];
         if (!fwatcherFiles[mfile]) fwatcherFiles[mfile] = [];
         if (fwatcherFiles[mfile].indexOf(file) >= 0) return;


### PR DESCRIPTION
The first commit abstracts the process of creating a watcher.  The second commit uses fs.realpathSync to resolve the true path of a file before registering the watcher.  While this is a somewhat naive way to handle the problem (which should probably be solved in chokidar), it is an elegant way to solve the problem until they fix things on their end.

It also stops us from breaking the test suite!  The latest version of chokidar causes the test suite to asplode... as does replacing chokidar with gaze (which can be used with an almost identical api).  You will notice there is a check to make sure that the real path of the file is not `private`, this is a check that is necessary if files are living in `$TMPDIR`
