### PR TITLE
bump browserify to v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "bin": "bin/cmd.js",
   "dependencies": {
-    "browserify": "^7.0.0",
+    "browserify": "^8.0.2",
     "chokidar": "~0.12.1",
     "through2": "~0.5.1"
   },


### PR DESCRIPTION
Passes all tests. Needed for https://github.com/substack/node-browserify/pull/1043.