### PR TITLE
--delay and --poll options

### DIFF
--- a/bin/args.js
+++ b/bin/args.js
@@ -2,8 +2,9 @@ var fromArgs = require('browserify/bin/args');
 var watchify = require('../');
 
 module.exports = function (args) {
-    return watchify(fromArgs(
-        process.argv.slice(2),
+    var browserify = fromArgs(
+        args,
         watchify.args
-    ));
+    );
+    return watchify(browserify, browserify.argv);
 };

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -37,7 +37,7 @@ function bundle () {
         fs.rename(dotfile, outfile, function (err) {
             if (err) return console.error(err);
             if (verbose) {
-                console.log(bytes + ' bytes written to ' + outfile
+                console.error(bytes + ' bytes written to ' + outfile
                     + ' (' + (time / 1000).toFixed(2) + ' seconds)'
                 );
             }

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-var watchify = require('../');
 var fs = require('fs');
 var path = require('path');
 
@@ -38,7 +37,7 @@ function bundle () {
         fs.rename(dotfile, outfile, function (err) {
             if (err) return console.error(err);
             if (verbose) {
-                console.error(bytes + ' bytes written to ' + outfile
+                console.log(bytes + ' bytes written to ' + outfile
                     + ' (' + (time / 1000).toFixed(2) + ' seconds)'
                 );
             }

--- a/index.js
+++ b/index.js
@@ -14,6 +14,11 @@ function watchify (b, opts) {
     var pkgcache = b._options.packageCache;
     var changingDeps = {};
     var pending = false;
+    var delay = typeof opts.delay === 'number' ? opts.delay : 600;
+    var chokidarOpts = {
+        persistent: true,
+        usePolling: opts.poll
+    };
     
     b.on('dep', function (dep) {
         if (typeof dep.id === 'string') {
@@ -80,7 +85,7 @@ function watchify (b, opts) {
         if (!fwatcherFiles[file]) fwatcherFiles[file] = [];
         if (fwatcherFiles[file].indexOf(file) >= 0) return;
         
-        var w = chokidar.watch(file, {persistent: true});
+        var w = chokidar.watch(file, chokidarOpts);
         w.setMaxListeners(0);
         w.on('error', b.emit.bind(b, 'error'));
         w.on('change', function () {
@@ -95,7 +100,7 @@ function watchify (b, opts) {
         if (!fwatcherFiles[mfile]) fwatcherFiles[mfile] = [];
         if (fwatcherFiles[mfile].indexOf(file) >= 0) return;
 
-        var w = chokidar.watch(file, {persistent: true});
+        var w = chokidar.watch(file, chokidarOpts);
         w.setMaxListeners(0);
         w.on('error', b.emit.bind(b, 'error'));
         w.on('change', function () {
@@ -122,7 +127,7 @@ function watchify (b, opts) {
             b.emit('update', Object.keys(changingDeps));
             changingDeps = {};
         
-        }, opts.delay || 600);
+        }, delay);
         pending = true;
     }
     


### PR DESCRIPTION
Adding some new features: `--poll` (enable chokidar polling) and `--delay` (for faster incremental bundling on some systems).

On my system this speeds up reload time by 600ms which is pretty huge. 

- fixing bin/args.js to use the `args` param and pass options to watchify
- removing unused require in bin/cmd.js
- making the existing `delay` option allow zero
- adding a `--poll` option for chokidar

Would be happy to add tests/docs etc. 