### PR TITLE
Fix to #56

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function watchify (b, opts) {
     var pkgcache = b._options.packageCache;
     var changingDeps = {};
     var pending = false;
-    
+
     b.on('dep', function (dep) {
         if (typeof dep.id === 'string') {
             cache[dep.id] = dep;
@@ -23,25 +23,25 @@ function watchify (b, opts) {
             watchFile(dep.file);
         }
     });
-    
+
     b.on('file', function (file) {
         watchFile(file);
     });
-    
+
     b.on('package', function (pkg) {
         watchFile(path.join(pkg.__dirname, 'package.json'));
     });
-    
+
     b.on('reset', reset);
     reset();
-    
+
     function reset () {
         var time = null;
         var bytes = 0;
         b.pipeline.get('record').on('end', function () {
             time = Date.now();
         });
-        
+
         b.pipeline.get('wrap').push(through(write, end));
         function write (buf, enc, next) {
             bytes += buf.length;
@@ -58,28 +58,50 @@ function watchify (b, opts) {
             this.push(null);
         }
     }
-    
+
     var fwatchers = {};
     var fwatcherFiles = {};
-    
+
+    if (opts.glob) {
+        var w = chokidar.watch(opts.glob, {ignoreInitial: true, persistent: true});
+        w.setMaxListeners(0);
+        w.on('error', b.emit.bind(b, 'error'));
+        w.on('add', function (file) {
+            b._options.entries.push(file);
+            b.constructor.call(b, b._options);
+            invalidate(file);
+        });
+        w.on('unlink', function (file) {
+            var i = b._options.entries.map(function (str) {
+                return path.resolve(str);
+            }).indexOf(path.resolve(file));
+            if (i === -1)
+                return;
+            b._options.entries.splice(i, 1);
+            b.constructor.call(b, b._options);
+            invalidate(file);
+        });
+        fwatchers.glob = w;
+    }
+
     b.on('transform', function (tr, mfile) {
         tr.on('file', function (file) {
             watchDepFile(mfile, file);
         });
     });
-    
+
     function watchFile (file) {
         fs.lstat(file, function (err, stat) {
             if (err || stat.isDirectory()) return;
             watchFile_(file);
         });
     }
-    
+
     function watchFile_ (file) {
         if (!fwatchers[file]) fwatchers[file] = [];
         if (!fwatcherFiles[file]) fwatcherFiles[file] = [];
         if (fwatcherFiles[file].indexOf(file) >= 0) return;
-        
+
         var w = chokidar.watch(file, {persistent: true});
         w.setMaxListeners(0);
         w.on('error', b.emit.bind(b, 'error'));
@@ -89,7 +111,7 @@ function watchify (b, opts) {
         fwatchers[file].push(w);
         fwatcherFiles[file].push(file);
     }
-    
+
     function watchDepFile(mfile, file) {
         if (!fwatchers[mfile]) fwatchers[mfile] = [];
         if (!fwatcherFiles[mfile]) fwatcherFiles[mfile] = [];
@@ -104,7 +126,7 @@ function watchify (b, opts) {
         fwatchers[mfile].push(w);
         fwatcherFiles[mfile].push(file);
     }
-    
+
     function invalidate (id) {
         if (cache) delete cache[id];
         if (fwatchers[id]) {
@@ -115,22 +137,22 @@ function watchify (b, opts) {
             delete fwatcherFiles[id];
         }
         changingDeps[id] = true
-        
+
         // wait for the disk/editor to quiet down first:
         if (!pending) setTimeout(function () {
             pending = false;
             b.emit('update', Object.keys(changingDeps));
             changingDeps = {};
-        
+
         }, opts.delay || 600);
         pending = true;
     }
-    
+
     b.close = function () {
         Object.keys(fwatchers).forEach(function (id) {
             fwatchers[id].forEach(function (w) { w.close() });
         });
     };
-    
+
     return b;
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bin": "bin/cmd.js",
   "dependencies": {
     "browserify": "^9.0.2",
-    "chokidar": "~0.12.1",
+    "chokidar": "^1.0.0-rc3",
     "through2": "~0.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Add/remove is done by calling the constructor, which retains the caches so builds remain fast.

I took this approach, since from my reading of the code, `reset()` needs to be called somewhere first so the pipeline can be modified, since `bundle()` was called previously. If there's a better way please let me know and I'll update the PR.