### PR TITLE
Allow options to be passed to chokidar

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,8 +79,10 @@ function watchify (b, opts) {
         if (!fwatchers[file]) fwatchers[file] = [];
         if (!fwatcherFiles[file]) fwatcherFiles[file] = [];
         if (fwatcherFiles[file].indexOf(file) >= 0) return;
-        
-        var w = chokidar.watch(file, {persistent: true});
+
+        var watchOpts = opts.watchOptions || {};
+        watchOpts.persistent = true;
+        var w = chokidar.watch(file, watchOpts);
         w.setMaxListeners(0);
         w.on('error', b.emit.bind(b, 'error'));
         w.on('change', function () {
@@ -95,7 +97,9 @@ function watchify (b, opts) {
         if (!fwatcherFiles[mfile]) fwatcherFiles[mfile] = [];
         if (fwatcherFiles[mfile].indexOf(file) >= 0) return;
 
-        var w = chokidar.watch(file, {persistent: true});
+        var watchOpts = opts.watchOptions || {};
+        watchOpts.persistent = true;
+        var w = chokidar.watch(file, watchOpts);
         w.setMaxListeners(0);
         w.on('error', b.emit.bind(b, 'error'));
         w.on('change', function () {


### PR DESCRIPTION
Allow the user to pass options to chokidar:
```javascript
var w = watchify(b, {watchOptions: {usePolling: true}});
```
The example given illustrates my use case -- when developing using Vagrant, filesystem events raised on the host don't propagate to the guest, so I'm forced to use polling.