### PR TITLE
Fix listeners leak in cmd.js

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -31,8 +31,8 @@ function bundle () {
     wb.pipe(fs.createWriteStream(dotfile));
     
     var bytes, time;
-    w.on('bytes', function (b) { bytes = b });
-    w.on('time', function (t) { time = t });
+    w.once('bytes', function (b) { bytes = b });
+    w.once('time', function (t) { time = t });
     
     wb.on('end', function () {
         fs.rename(dotfile, outfile, function (err) {


### PR DESCRIPTION
Each call of `bundle` function registered new listeners to get `bytes` and `time`, and it never removed them.