### PR TITLE
Fix EPERM on windows

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -34,14 +34,23 @@ function bundle () {
     w.on('bytes', function (b) { bytes = b });
     w.on('time', function (t) { time = t });
     
-    wb.on('end', function () {
+    wb.on('end', rename.bind(null, 0));
+    
+    function rename(retryCount) {
+        if (!retryCount || typeof retryCount !== 'number') retryCount = 0;
         fs.rename(dotfile, outfile, function (err) {
-            if (err) return console.error(err);
-            if (verbose) {
+            if (err) {
+                if (retryCount < 3) {
+                    console.error('retrying');
+                    setTimeout(rename, 100, retryCount+1);
+                }
+                else console.error(err);
+            }
+            else if (verbose) {
                 console.error(bytes + ' bytes written to ' + outfile
                     + ' (' + (time / 1000).toFixed(2) + ' seconds)'
                 );
             }
         });
-    });
+    }
 }

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -23,10 +23,10 @@ function bundle () {
     var wb = w.bundle();
     wb.on('error', function (err) {
         console.error(String(err));
-        fs.writeFile(outfile, 'console.error('+JSON.stringify(String(err))+')', logIfErr)
+        fs.writeFile(outfile, 'console.error('+JSON.stringify(String(err))+')', logIfErr);
     });
     wb.pipe(fs.createWriteStream(dotfile)).on('error', logIfErr);
-    
+
     var bytes, time;
     w.on('bytes', function (b) { bytes = b });
     w.on('time', function (t) { time = t });
@@ -58,5 +58,5 @@ function bundle () {
 }
 
 function logIfErr(err) {
-    if (err) console.error(String(err))
+    if (err) console.error(String(err));
 }


### PR DESCRIPTION
Fixes #83.

If it gets an EPERM error when renaming, it will copy the dotfile to the outfile and delete the dotfile, effectively renaming it.

**Edit:** The comment chain below is outdated.