### PR TITLE
Fix permissions error (EPERM) on Windows

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -3,6 +3,7 @@
 var watchify = require('../');
 var fs = require('fs');
 var path = require('path');
+var concat = require('concat-stream');
 
 var fromArgs = require('./args.js');
 var w = fromArgs(process.argv.slice(2));
@@ -15,7 +16,6 @@ if (!outfile) {
     console.error('You MUST specify an outfile with -o.');
     process.exit(1);
 }
-var dotfile = path.join(path.dirname(outfile), '.' + path.basename(outfile));
 
 w.on('update', bundle);
 bundle();
@@ -28,20 +28,21 @@ function bundle () {
             if (err) console.error(err);
         })
     });
-    wb.pipe(fs.createWriteStream(dotfile));
+    wb.pipe(concat(function (buf) {
+		fs.writeFile(outfile, buf, function (err) {
+			if (err) console.error(String(err));
+		})
+	}));
     
     var bytes, time;
     w.on('bytes', function (b) { bytes = b });
     w.on('time', function (t) { time = t });
     
     wb.on('end', function () {
-        fs.rename(dotfile, outfile, function (err) {
-            if (err) return console.error(err);
-            if (verbose) {
-                console.error(bytes + ' bytes written to ' + outfile
-                    + ' (' + (time / 1000).toFixed(2) + ' seconds)'
-                );
-            }
-        });
+		if (verbose) {
+			console.error(bytes + ' bytes written to ' + outfile
+				+ ' (' + (time / 1000).toFixed(2) + ' seconds)'
+			);
+		}
     });
 }

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -29,20 +29,17 @@ function bundle () {
         })
     });
     wb.pipe(concat(function (buf) {
-		fs.writeFile(outfile, buf, function (err) {
-			if (err) console.error(String(err));
-		})
-	}));
+        fs.writeFile(outfile, buf, function (err) {
+            if (err) return console.error(String(err));
+            if (verbose) {
+                console.error(bytes + ' bytes written to ' + outfile
+                    + ' (' + (time / 1000).toFixed(2) + ' seconds)'
+                );
+            }
+        });
+    }));
     
     var bytes, time;
     w.on('bytes', function (b) { bytes = b });
     w.on('time', function (t) { time = t });
-    
-    wb.on('end', function () {
-		if (verbose) {
-			console.error(bytes + ' bytes written to ' + outfile
-				+ ' (' + (time / 1000).toFixed(2) + ' seconds)'
-			);
-		}
-    });
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "browserify": "^9.0.2",
     "chokidar": "~0.12.1",
+	"concat-stream": "^1.4.7",
     "through2": "~0.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The dotfile was getting permissions errors on windows.

This fixes the issue by buffering in memory rather than writing to a dotfile.

Memory usage was similar in my tests. (Write to dotfile: 42k, Buffer in memory: 42-44k.)

Fixes #83.

Related: #103, #104, #156.