### PR TITLE
"fullPaths" optional again

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "dependencies": {
     "browserify": "^9.0.2",
     "chokidar": "~0.12.1",
-    "through2": "~0.5.1"
+    "through2": "~0.5.1",
+    "xtend": "^4.0.0"
   },
   "devDependencies": {
     "brfs": "^1.0.1",

--- a/readme.markdown
+++ b/readme.markdown
@@ -51,7 +51,7 @@ When creating the browserify instance `b` you MUST set these properties in the
 constructor:
 
 ``` js
-var b = browserify({ cache: {}, packageCache: {}, fullPaths: true })
+var b = browserify({ cache: {}, packageCache: {} })
 ```
 
 You can also just do:


### PR DESCRIPTION
This diff makes `fullPaths` optional again. Instead of waiting for `browserify` to emit `dep` via `emit-deps`, we get the `rows` immediately after `deps` - but not the entire row, just the parts that are relevant for caching. Since `module-deps` only [cares](https://github.com/substack/module-deps/blob/574ed9a57cc637480a93b3072659cd5a0eca6435/index.js#L348-L349) about `id`, `source`, `deps` and `file` from a cache perspective.

This also fixes an issue whereby, after each re-build, every `.json` file would get an extra `module.exports=` prepended (see https://github.com/substack/watchify/pull/152). This happened because cached files where being re-fed into the pipeline that had already been through the `json` step.

It's also unnecessary to `fs.stat` each file. It is a given that a `row` emitted by `module-deps` has a `file` property which corresponds to a file and that it exists.

Disclaimer: I don't know if there was an obscure underlying reason that I might've missed for why `watchify` observed `dep` instead of tapping into the pipeline.

cc: @substack @feross @jmm