### PR TITLE
add --delay option for faster builds

### DIFF
--- a/bin/args.js
+++ b/bin/args.js
@@ -2,8 +2,9 @@ var fromArgs = require('browserify/bin/args');
 var watchify = require('../');
 
 module.exports = function (args) {
-    return watchify(fromArgs(
+    var browserify = fromArgs(
         args || process.argv.slice(2),
         watchify.args
-    ));
+    );
+    return watchify(browserify, browserify.argv);
 };

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ function watchify (b, opts) {
     if (!opts) opts = {};
     var cache = b._options.cache;
     var pkgcache = b._options.packageCache;
+    var delay = typeof opts.delay === 'number' ? opts.delay : 600;
     var changingDeps = {};
     var pending = false;
     
@@ -125,7 +126,7 @@ function watchify (b, opts) {
             b.emit('update', Object.keys(changingDeps));
             changingDeps = {};
         
-        }, opts.delay || 600);
+        }, delay);
         pending = true;
     }
     


### PR DESCRIPTION
To get around the hard-coded 600ms delay:

```watchify index.js --delay 0 --output bundle.js```