### PR TITLE
Use tmpdir for test output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 node_modules
-test/tmp

--- a/test/api_brfs.js
+++ b/test/api_brfs.js
@@ -9,7 +9,7 @@ var mkdirp = require('mkdirp');
 var split = require('split');
 
 var os = require('os');
-var tmpdir = path.join(__dirname, 'tmp', Math.random() + '');
+var tmpdir = path.join((os.tmpdir || os.tmpDir)(), 'watchify-' + Math.random());
 
 var files = {
     main: path.join(tmpdir, 'main.js'),

--- a/test/errors.js
+++ b/test/errors.js
@@ -9,7 +9,7 @@ var mkdirp = require('mkdirp');
 var split = require('split');
 
 var os = require('os');
-var tmpdir = path.join(__dirname, 'tmp', Math.random() + '');
+var tmpdir = path.join((os.tmpdir || os.tmpDir)(), 'watchify-' + Math.random());
 
 var file = path.join(tmpdir, 'main.js');
 

--- a/test/errors_transform.js
+++ b/test/errors_transform.js
@@ -9,7 +9,7 @@ var mkdirp = require('mkdirp');
 var through = require('through2');
 
 var os = require('os');
-var tmpdir = path.join(__dirname, 'tmp', Math.random() + '');
+var tmpdir = path.join((os.tmpdir || os.tmpDir)(), 'watchify-' + Math.random());
 
 var main = path.join(tmpdir, 'main.js');
 var file = path.join(tmpdir, 'dep.jsnum');


### PR DESCRIPTION
Only there 3 tests are not using `tmpdir`. It was explicitly removed in https://github.com/substack/watchify/commit/d1a691d. @substack Any particular reason?