### PR TITLE
Don't re-add "bytes" and "time" listeners on rebundle

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -6,7 +6,6 @@ var path = require('path');
 
 var fromArgs = require('./args.js');
 var w = fromArgs(process.argv.slice(2));
-w.setMaxListeners(Infinity);
 
 var outfile = w.argv.o || w.argv.outfile;
 var verbose = w.argv.v || w.argv.verbose;
@@ -16,6 +15,10 @@ if (!outfile) {
     process.exit(1);
 }
 var dotfile = path.join(path.dirname(outfile), '.' + path.basename(outfile));
+
+var bytes, time;
+w.on('bytes', function (b) { bytes = b });
+w.on('time', function (t) { time = t });
 
 w.on('update', bundle);
 bundle();
@@ -29,10 +32,6 @@ function bundle () {
         })
     });
     wb.pipe(fs.createWriteStream(dotfile));
-    
-    var bytes, time;
-    w.on('bytes', function (b) { bytes = b });
-    w.on('time', function (t) { time = t });
     
     wb.on('end', function () {
         fs.rename(dotfile, outfile, function (err) {


### PR DESCRIPTION
The `bytes` and `time` listeners are getting re-added on every re-bundle. https://github.com/substack/watchify/pull/155 proposes to fix this by adding the listeners with `once` instead of `on`. This works for cases when the build was successful, but if there was a build error, those handlers will never fire, thus never get unbound. To account for that would require that we hold references to listener functions and call `removeListener` with them if an error occurs - but that's too much.

It's easier to just bind the events one time when the browserify instance is created. This might lead to inconsistent log output if there is a race between concurrent rebuilds - but that's highly unlikely.

cc: @substack