### PR TITLE
Skip temp file

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-var watchify = require('../');
 var fs = require('fs');
 var path = require('path');
 var os = require('os');

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
 
 var fs = require('fs');
-var path = require('path');
-var os = require('os');
 
 var fromArgs = require('./args.js');
 var w = fromArgs(process.argv.slice(2));
@@ -15,9 +13,6 @@ if (!outfile) {
     process.exit(1);
 }
 
-var tmpname = 'watchify-' + Math.random() + '-' + path.basename(outfile);
-var tmpfile = path.join((os.tmpdir || os.tmpDir)(), tmpname);
-
 var bytes, time;
 w.on('bytes', function (b) { bytes = b });
 w.on('time', function (t) { time = t });
@@ -27,27 +22,24 @@ bundle();
 
 function bundle () {
     var didError = false;
-    var tmpStream = fs.createWriteStream(tmpfile);
+    var outStream = fs.createWriteStream(outfile);
 
     var wb = w.bundle();
     wb.on('error', function (err) {
         console.error(String(err));
         didError = true;
-        tmpStream.end('console.error('+JSON.stringify(String(err))+');');
+        outStream.end('console.error('+JSON.stringify(String(err))+');');
     });
-    wb.pipe(tmpStream);
+    wb.pipe(outStream);
 
-    tmpStream.on('error', function (err) {
+    outStream.on('error', function (err) {
         console.error(err);
     });
-    tmpStream.on('close', function () {
-        fs.rename(tmpfile, outfile, function (err) {
-            if (err) return console.error(err);
-            if (verbose && !didError) {
-                console.error(bytes + ' bytes written to ' + outfile
-                    + ' (' + (time / 1000).toFixed(2) + ' seconds)'
-                );
-            }
-        });
+    outStream.on('close', function () {
+        if (verbose && !didError) {
+            console.error(bytes + ' bytes written to ' + outfile
+                + ' (' + (time / 1000).toFixed(2) + ' seconds)'
+            );
+        }
     });
 }


### PR DESCRIPTION
Using a dot file in the same dir as the outfile causes problems like https://github.com/substack/watchify/issues/140 https://github.com/substack/watchify/issues/154.

Using the system tmp dir and then renaming doesn't work across partitions https://github.com/substack/watchify/issues/171.

Despite https://github.com/substack/watchify/pull/161/files#issuecomment-84511330 ("[the] feature was added in the first place to protect against delivering incomplete, partial content"), we should try not using an intermediate file. This how browserify already works when you use its `--outfile` option. I would argue that receiving incomplete/partial content because the user didn't wait is no more egregious than writing out to the file a `console.log(JSON.stringify(err));` - since incomplete content will almost certainly be syntactically invalid and thus would error if used.