### PR TITLE
When the compile process has completed, copy the tempfile instead of renaming it

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -42,13 +42,19 @@ function bundle () {
         console.error(err);
     });
     tmpStream.on('close', function () {
-        fs.rename(tmpfile, outfile, function (err) {
+        fs.readFile(tmpfile, function (err, data) {
             if (err) return console.error(err);
-            if (verbose && !didError) {
-                console.error(bytes + ' bytes written to ' + outfile
-                    + ' (' + (time / 1000).toFixed(2) + ' seconds)'
-                );
-            }
+
+            fs.writeFile(outfile, data, function (err) {
+                if (err) return console.error(err);
+                if (verbose && !didError) {
+                    console.error(bytes + ' bytes written to ' + outfile
+                        + ' (' + (time / 1000).toFixed(2) + ' seconds)'
+                    );
+                }
+
+                fs.unlinkSync(tmpfile);
+            })
         });
     });
 }

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -41,20 +41,24 @@ function bundle () {
     tmpStream.on('error', function (err) {
         console.error(err);
     });
+
     tmpStream.on('close', function () {
-        fs.readFile(tmpfile, function (err, data) {
-            if (err) return console.error(err);
+        var tmpReadStream = fs.createReadStream(tmpfile);
+        var outStream = fs.createWriteStream(outfile);
 
-            fs.writeFile(outfile, data, function (err) {
-                if (err) return console.error(err);
-                if (verbose && !didError) {
-                    console.error(bytes + ' bytes written to ' + outfile
-                        + ' (' + (time / 1000).toFixed(2) + ' seconds)'
-                    );
-                }
+        tmpReadStream.on('error', function (err) {
+            console.error(err);
+        });
 
-                fs.unlinkSync(tmpfile);
-            })
+        tmpReadStream.pipe(outStream);
+        tmpReadStream.on('end',function() {
+            if (verbose && !didError) {
+                console.error(bytes + ' bytes written to ' + outfile
+                    + ' (' + (time / 1000).toFixed(2) + ' seconds)'
+                );
+            }
+
+            fs.unlinkSync(tmpfile);
         });
     });
 }


### PR DESCRIPTION
Renaming the tempfile is not safe, since it cannot move a file from one partition to another. This limititation causes trouble on systems where the temp folder on a separate partition, or when a project is placed on a removable drive.

Therefore I think the file should be copied instead.