### PR TITLE
"-o" can be a shell command

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 var fs = require('fs');
+var outpipe = require('outpipe');
 
 var fromArgs = require('./args.js');
 var w = fromArgs(process.argv.slice(2));
@@ -22,7 +23,9 @@ bundle();
 
 function bundle () {
     var didError = false;
-    var outStream = fs.createWriteStream(outfile);
+    var outStream = process.platform === 'win32'
+        ? fs.createWriteStream(outfile)
+        : outpipe(outfile);
 
     var wb = w.bundle();
     wb.on('error', function (err) {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "browserify": "^9.0.2",
     "chokidar": "^1.0.0-rc4",
     "defined": "~0.0.0",
+    "outpipe": "^1.1.0",
     "through2": "~0.6.3",
     "xtend": "^4.0.0"
   },

--- a/readme.markdown
+++ b/readme.markdown
@@ -1,6 +1,6 @@
 # watchify
 
-watch mode for browserify builds
+watch mode for [browserify](https://github.com/substack/node-browserify) builds
 
 [![build status](https://secure.travis-ci.org/substack/watchify.png)](http://travis-ci.org/substack/watchify)
 
@@ -15,6 +15,17 @@ $ watchify main.js -o static/bundle.js
 
 Now as you update files, `static/bundle.js` will be automatically incrementally rebuilt on
 the fly.
+
+The `-o` option can be a file or a shell command (not available on Windows)
+that receives piped input:
+
+``` sh
+watchify main.js -o 'exorcist static/bundle.js.map > static/bundle.js' -d
+```
+
+``` sh
+watchify main.js -o 'uglifyjs -cm > static/bundle.min.js'
+```
 
 You can use `-v` to get more verbose output to show when a file was written and how long the bundling took (in seconds):
 
@@ -38,7 +49,10 @@ Standard Options:
 
   --outfile=FILE, -o FILE
 
-    Write the browserify bundle to this file. This option is required.
+    This option is required. Write the browserify bundle to this file. If
+    the file contains the operators `|` or `>`, it will be treated as a
+    shell command, and the output will be piped to it (not available on
+    Windows).
 
   --verbose, -v                     [default: false]
 

--- a/test/bin_pipe.js
+++ b/test/bin_pipe.js
@@ -1,0 +1,61 @@
+var test = require('tape');
+var fs = require('fs');
+var path = require('path');
+var mkdirp = require('mkdirp');
+var spawn = require('win-spawn');
+var split = require('split');
+
+var cmd = path.resolve(__dirname, '../bin/cmd.js');
+var os = require('os');
+var tmpdir = path.join((os.tmpdir || os.tmpDir)(), 'watchify-' + Math.random());
+
+var files = {
+    main: path.join(tmpdir, 'main.js'),
+    bundle: path.join(tmpdir, 'bundle.js')
+};
+
+mkdirp.sync(tmpdir);
+fs.writeFileSync(files.main, 'console.log(9+9+555)');
+
+test('bin with pipe', function (t) {
+    if (process.platform === 'win32') {
+        t.skip('not for windows');
+        t.end();
+        return;
+    }
+    t.plan(4);
+    var ps = spawn(cmd, [
+        files.main,
+        '-o', 'sed "s/9+9+//" > ' + files.bundle,
+        '-v'
+    ]);
+    var lineNum = 0;
+    ps.stderr.pipe(split()).on('data', function (line) {
+        lineNum ++;
+        if (lineNum === 1) {
+            run(files.bundle, function (err, output) {
+                t.ifError(err);
+                t.equal(output, '555\n');
+                fs.writeFile(files.main, 'console.log(9+9+333)');
+            });
+        }
+        else if (lineNum === 2) {
+            run(files.bundle, function (err, output) {
+                t.ifError(err);
+                t.equal(output, '333\n');
+                ps.kill();
+            });
+        }
+    });
+});
+
+function run (file, cb) {
+    var ps = spawn(process.execPath, [ file ]);
+    var data = [];
+    ps.stdout.on('data', function (buf) { data.push(buf) });
+    ps.stdout.on('end', function () {
+        cb(null, Buffer.concat(data).toString('utf8'));
+    });
+    ps.on('error', cb);
+    return ps;
+}


### PR DESCRIPTION
Fixes https://github.com/substack/watchify/issues/16. By using [outpipe](https://github.com/substack/outpipe), we can now do this:

``` sh
watchify main.js -o 'exorcist static/bundle.js.map > static/bundle.js' -d
```

``` sh
watchify main.js -o 'uglifyjs -cm > static/bundle.min.js'
```