### PR TITLE
do not register a watcher on basedir

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,6 @@ function watchify (b, opts) {
     });
     
     function watchFile (file) {
-        if (b._mdeps.top.basedir === file) return;
         if (!fwatchers[file]) fwatchers[file] = [];
         if (!fwatcherFiles[file]) fwatcherFiles[file] = [];
         if (fwatcherFiles[file].indexOf(file) >= 0) return;
@@ -102,6 +101,7 @@ function watchify (b, opts) {
         w.setMaxListeners(0);
         w.on('error', b.emit.bind(b, 'error'));
         w.on('change', function () {
+            if (b._mdeps.top.basedir === file) return;  
             invalidate(file);
         });
         fwatchers[file].push(w);

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function watchify (b, opts) {
     var delay = typeof opts.delay === 'number' ? opts.delay : 600;
     var changingDeps = {};
     var pending = false;
-
+    
     var wopts = {persistent: true};
     if (opts.ignoreWatch) {
         wopts.ignored = opts.ignoreWatch !== true
@@ -31,7 +31,7 @@ function watchify (b, opts) {
 
     b.on('reset', collect);
     collect();
-
+    
     function collect () {
         b.pipeline.get('deps').push(through.obj(function(row, enc, next) {
             if (cache) {
@@ -47,25 +47,25 @@ function watchify (b, opts) {
             next();
         }));
     }
-
+    
     b.on('file', function (file) {
         watchFile(file);
     });
-
+    
     b.on('package', function (pkg) {
         watchFile(path.join(pkg.__dirname, 'package.json'));
     });
-
+    
     b.on('reset', reset);
     reset();
-
+    
     function reset () {
         var time = null;
         var bytes = 0;
         b.pipeline.get('record').on('end', function () {
             time = Date.now();
         });
-
+        
         b.pipeline.get('wrap').push(through(write, end));
         function write (buf, enc, next) {
             bytes += buf.length;
@@ -82,22 +82,22 @@ function watchify (b, opts) {
             this.push(null);
         }
     }
-
+    
     var fwatchers = {};
     var fwatcherFiles = {};
-
+    
     b.on('transform', function (tr, mfile) {
         tr.on('file', function (file) {
             watchDepFile(mfile, file);
         });
     });
-
+    
     function watchFile (file) {
-        if (b._mdeps.top.basedir === file) return; 
+        if (b._mdeps.top.basedir === file) return;
         if (!fwatchers[file]) fwatchers[file] = [];
         if (!fwatcherFiles[file]) fwatcherFiles[file] = [];
         if (fwatcherFiles[file].indexOf(file) >= 0) return;
-
+        
         var w = b._watcher(file, wopts);
         w.setMaxListeners(0);
         w.on('error', b.emit.bind(b, 'error'));
@@ -107,7 +107,7 @@ function watchify (b, opts) {
         fwatchers[file].push(w);
         fwatcherFiles[file].push(file);
     }
-
+    
     function watchDepFile(mfile, file) {
         if (!fwatchers[mfile]) fwatchers[mfile] = [];
         if (!fwatcherFiles[mfile]) fwatcherFiles[mfile] = [];
@@ -122,7 +122,7 @@ function watchify (b, opts) {
         fwatchers[mfile].push(w);
         fwatcherFiles[mfile].push(file);
     }
-
+    
     function invalidate (id) {
         if (cache) delete cache[id];
         if (fwatchers[id]) {
@@ -133,23 +133,23 @@ function watchify (b, opts) {
             delete fwatcherFiles[id];
         }
         changingDeps[id] = true
-
+        
         // wait for the disk/editor to quiet down first:
         if (!pending) setTimeout(function () {
             pending = false;
             b.emit('update', Object.keys(changingDeps));
             changingDeps = {};
-
+        
         }, delay);
         pending = true;
     }
-
+    
     b.close = function () {
         Object.keys(fwatchers).forEach(function (id) {
             fwatchers[id].forEach(function (w) { w.close() });
         });
     };
-
+    
     b._watcher = function (file, opts) {
         return chokidar.watch(file, opts);
     };


### PR DESCRIPTION
On OS X, watchify is getting stuck in constant recompile when running from command `watchify . -o myfile.js -d -v`. I threw logging in and the basedir is the trigger. Seems like chokidar is raising the change event on the basedir -- as a result of the outfile being written or maybe a timestamp change on the folder? Oddly, have not seen the same behavior on Windows. 

Either way, checking the file to see if it is the basedir before registering a watcher seems to resolve the issue (line 96).
