### PR TITLE
Fix success logging, should be written to stdout

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -40,7 +40,7 @@ function bundle () {
     });
     outStream.on('close', function () {
         if (verbose && !didError) {
-            console.error(bytes + ' bytes written to ' + outfile
+            console.info(bytes + ' bytes written to ' + outfile
                 + ' (' + (time / 1000).toFixed(2) + ' seconds)'
             );
         }


### PR DESCRIPTION
Confuses users when this shows up in error logs (e.g, stderr is being aggregated)