### PR TITLE
Add/ignoring handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var through = require('through2');
 var path = require('path');
 var chokidar = require('chokidar');
 var xtend = require('xtend');
+var anymatch = require('anymatch');
 
 module.exports = watchify;
 module.exports.args = {

--- a/index.js
+++ b/index.js
@@ -94,6 +94,8 @@ function watchify (b, opts) {
     });
     
     function watchFile (file) {
+        if (anymatch(opts.ignoreWatch, file)) return false;
+
         if (!fwatchers[file]) fwatchers[file] = [];
         if (!fwatcherFiles[file]) fwatcherFiles[file] = [];
         if (fwatcherFiles[file].indexOf(file) >= 0) return;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "defined": "~0.0.0",
     "outpipe": "^1.1.0",
     "through2": "~0.6.3",
+    "anymatch": "1.2.1",
     "xtend": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR avoids create `chokidar` watcher instances when the file matchs with the ignoring rule defined through `--ignore-watch` parameter so the idea try to is optimize resources.