### PR TITLE
Make `args` a function, to prevent inadvertent sharing of caches across instances

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ var chokidar = require('chokidar');
 var xtend = require('xtend');
 
 module.exports = watchify;
-module.exports.args = {
-    cache: {}, packageCache: {}
+module.exports.args = function () {
+    return {cache: {}, packageCache: {}};
 };
 
 function watchify (b, opts) {


### PR DESCRIPTION
Isn't [this](https://github.com/substack/watchify/blob/1a7de4dc20a33026de5576bae5e4236bcbcd9d9c/index.js#L7-L9)...

```js
module.exports.args = {
    cache: {}, packageCache: {}
};
```
...and this...

> You can also just do:
```js
var b = browserify(watchify.args);
```

...a bad idea to naively encourage? A la @zertosh https://github.com/substack/watchify/issues/187#issuecomment-89688765.

If so, this PR would change the usage to:
```js
var b = browserify(watchify.args());
```

If this change moves forward there are tests to fix, docs to update etc. I decided to stop here until I see what you think about the idea in general, and about backcompat if you're favorable.

* Preserve partial BC by making `args` a getter.
* Preserve full BC by making a new export, e.g. `getArgs()`.
* Break BC.

Exporting a function would also make it simple to provide the following convenience if you want to:

```js
// Merge passed opts with the watchify args.
watchify.args({debug: true, ...})
```
