### PR TITLE
Soft deprecate "watchify.args"

### DIFF
--- a/bin/args.js
+++ b/bin/args.js
@@ -4,7 +4,7 @@ var defined = require('defined');
 var xtend = require('xtend');
 
 module.exports = function (args) {
-    var b = fromArgs(args, watchify.args);
+    var b = fromArgs(args, watchify.defaults());
 
     var opts = {};
     var ignoreWatch = defined(b.argv['ignore-watch'], b.argv.iw);

--- a/index.js
+++ b/index.js
@@ -4,9 +4,11 @@ var chokidar = require('chokidar');
 var xtend = require('xtend');
 
 module.exports = watchify;
-module.exports.args = {
-    cache: {}, packageCache: {}
+module.exports.defaults = function (opts) {
+    return xtend({cache: {}, packageCache: {}}, opts);
 };
+// DEPRECATED - will be removed in a future version
+module.exports.args = watchify.defaults();
 
 function watchify (b, opts) {
     if (!opts) opts = {};

--- a/readme.markdown
+++ b/readme.markdown
@@ -103,13 +103,6 @@ var b = browserify({ cache: {}, packageCache: {} });
 var w = watchify(b);
 ```
 
-You can also just do:
-
-``` js
-var b = browserify(watchify.args);
-var w = watchify(b);
-```
-
 `w` is exactly like a browserify bundle except that caches file contents and
 emits an `'update'` event when a file changes. You should call `w.bundle()`
 after the `'update'` event fires to generate a new bundle. Calling `w.bundle()`


### PR DESCRIPTION
Users are unwittingly sharing caches across browserify instances. There is discussion on alternatives in https://github.com/substack/watchify/pull/204.

The solution proposed here is just the basis for a developer education campaign. The idea is to still have `watchify.args`, but not document it. Instead insist that users use `{cache: {}, packageCache: {}}` in the main README, and across the various "recipes" sites (e.g. [gulp](https://github.com/gulpjs/gulp/blob/master/docs/recipes/fast-browserify-builds-with-watchify.md), [gulp-watchify](https://github.com/marcello3d/gulp-watchify/blob/0ff6362f8ad521fb357c8a6563e36e932888bea0/index.js#L17)). This way we don't break existing code.

I'm on the fence about `watchify.defaults` being internal or not.
