### PR TITLE
Desktop notifications support

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "browserify": "^10.0.0",
     "chokidar": "^1.0.0",
     "defined": "^1.0.0",
+    "node-notifier": "^4.2.1",
     "outpipe": "^1.1.0",
     "through2": "~0.6.3",
     "xtend": "^4.0.0"

--- a/readme.markdown
+++ b/readme.markdown
@@ -59,9 +59,15 @@ Standard Options:
     Show when a file was written and how long the bundling took (in
     seconds).
 
+  --notify, -n						[default: false]
+
+	Show desktop notifications using node-notifier 
+	(https://github.com/madhums/node-notifier) for errors and activity
+
   --version
 
     Show the watchify and browserify versions with their module paths.
+	
 ```
 
 ```

--- a/test/many.js
+++ b/test/many.js
@@ -57,7 +57,7 @@ fs.writeFileSync(files.lines, 'beep\nboop');
 test('many edits', function (t) {
     t.plan(expected.length * 2 + edits.length);
     var ps = spawn(cmd, [
-        files.main,
+        files.main, '-n',
         '-t', require.resolve('brfs'), '-v',
         '-o', files.bundle
     ]);


### PR DESCRIPTION
-n option for Desktop notifications using node-notifier (https://github.com/madhums/node-notifier) for errors and activity