### PR TITLE
Don't cache external dependencies.

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,9 +37,14 @@ function watchify (b, opts) {
     function collect () {
         b.pipeline.get('deps').push(through.obj(function(row, enc, next) {
             var file = row.expose ? b._expose[row.id] : row.file;
+            var deps = xtend({}, row.deps);
+            Object.keys(deps).forEach(function(dep) {
+                // External dependency(doesn't have a file path).
+                if (deps[dep] == null) delete deps[dep];
+            });
             cache[file] = {
                 source: row.source,
-                deps: xtend({}, row.deps)
+                deps: deps
             };
             this.push(row);
             next();


### PR DESCRIPTION
Fix the `collect()` function so it won't collect external dependencies,
consequently breaking module-deps when it tries to read the file later:
https://github.com/substack/module-deps/blob/1592d483d0/index.js#L189