### PR TITLE
Don't add a watcher to files which should be ignored.

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ function watchify (b, opts) {
         dep = dep || file;
         // if we're not supposed to ignore anything, or if the file doesn't match the ignore
         // glob, then add a watcher for it
-        if (!wopts.ignored || !anymatch([wopts.ignored], file)) {
+        if (!wopts.ignored || !anymatch([wopts.ignored], dep)) {
           if (!fwatchers[file]) fwatchers[file] = [];
           if (!fwatcherFiles[file]) fwatcherFiles[file] = [];
           if (fwatcherFiles[file].indexOf(dep) >= 0) return;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "bin": "bin/cmd.js",
   "dependencies": {
+    "anymatch": "^1.3.0",
     "browserify": "^10.0.0",
     "chokidar": "^1.0.0",
     "defined": "^1.0.0",


### PR DESCRIPTION
If you call `chokidar.watch(path, { ignored: '/some/string/that/matches/path' });` it'll still add a watcher to the file.

This adds a filter in `watchFile` which prevents the watcher from getting added if it matches the `ignored` glob.

This avoided watching files in `node_modules` for a particular project I'm working on and also corrected a segfault which would occur as a result (because of the watch handlers attached to files which were removed via an `npm update` call).