### PR TITLE
Don't attach a watcher for files which are ignored.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var through = require('through2');
 var path = require('path');
 var chokidar = require('chokidar');
 var xtend = require('xtend');
+var anymatch = require('anymatch');
 
 module.exports = watchify;
 module.exports.args = {
@@ -85,6 +86,7 @@ function watchify (b, opts) {
     
     var fwatchers = {};
     var fwatcherFiles = {};
+    var ignoredFiles = {};
     
     b.on('transform', function (tr, mfile) {
         tr.on('file', function (dep) {
@@ -94,6 +96,11 @@ function watchify (b, opts) {
 
     function watchFile (file, dep) {
         dep = dep || file;
+        // don't watch files which are explicitly ignored
+        if (wopts.ignored && (ignoredFiles[file] || anymatch([wopts.ignored], dep))) {
+          ignoredFiles[file] = true;
+          return;
+        }
         if (!fwatchers[file]) fwatchers[file] = [];
         if (!fwatcherFiles[file]) fwatcherFiles[file] = [];
         if (fwatcherFiles[file].indexOf(dep) >= 0) return;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "bin": "bin/cmd.js",
   "dependencies": {
+    "anymatch": "^1.3.0",
     "browserify": "^10.0.0",
     "chokidar": "^1.0.0",
     "defined": "^1.0.0",


### PR DESCRIPTION
@zertosh Updated PR with the fix such that a watcher isn't attached to files which are explicitly ignored.