### PR TITLE
not updating race condition fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,7 @@ function watchify (b, opts) {
         });
     });
     b.on('bundle', function (bundle) {
+        updating = true;
         bundle.on('error', onend);
         bundle.on('end', onend);
         function onend () { updating = false }
@@ -141,7 +142,6 @@ function watchify (b, opts) {
             pending = false;
             if (!updating) {
                 b.emit('update', Object.keys(changingDeps));
-                updating = true;
                 changingDeps = {};
             }
         }, delay);

--- a/index.js
+++ b/index.js
@@ -97,10 +97,10 @@ function watchify (b, opts) {
     function watchFile (file, dep) {
         dep = dep || file;
         if (ignored) {
-          if (!ignoredFiles.hasOwnProperty(file)) {
-            ignoredFiles[file] = anymatch(ignored, file);
-          }
-          if (ignoredFiles[file]) return;
+            if (!ignoredFiles.hasOwnProperty(file)) {
+                ignoredFiles[file] = anymatch(ignored, file);
+            }
+            if (ignoredFiles[file]) return;
         }
         if (!fwatchers[file]) fwatchers[file] = [];
         if (!fwatcherFiles[file]) fwatcherFiles[file] = [];
@@ -126,7 +126,7 @@ function watchify (b, opts) {
             delete fwatchers[id];
             delete fwatcherFiles[id];
         }
-        changingDeps[id] = true
+        changingDeps[id] = true;
         
         // wait for the disk/editor to quiet down first:
         if (!pending) setTimeout(function () {

--- a/index.js
+++ b/index.js
@@ -95,7 +95,6 @@ function watchify (b, opts) {
         });
     });
     b.on('bundle', function (bundle) {
-        updating = true;
         bundle.on('error', onend);
         bundle.on('end', onend);
         function onend () { updating = false }
@@ -141,6 +140,7 @@ function watchify (b, opts) {
         if (!pending) setTimeout(function () {
             pending = false;
             if (!updating) {
+                updating = true;
                 b.emit('update', Object.keys(changingDeps));
                 changingDeps = {};
             }


### PR DESCRIPTION
This patch fixes #216 by tracking the updating status and refusing to close watchers while the new bundle is being generated. Previously, a race condition would remove watchers from `fwatchers` when 2 parallel 'update' events would use the same data structures.

This issue is easy to replicate on a big project by doing: `while true; do touch main.js; done`. Before, this would stop watchify from tracking changes to `main.js` very quickly. With this fix, watchify keeps on cranking.