### PR TITLE
fix for `end` event of bundle is never triggered

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,6 +96,11 @@ function watchify (b, opts) {
     });
     b.on('bundle', function (bundle) {
         updating = true;
+        // somehow if we don't listen to `data` event
+        // `end` event is never triggered
+        // not sure why this is hapening,
+        // it should be a temp fix
+        bundle.on('data', function() {});
         bundle.on('error', onend);
         bundle.on('end', onend);
         function onend () { updating = false }


### PR DESCRIPTION
I come across an issue when the watchify upgrades to 3.3.1.
So I'm using grunt-browserify in my current build process, and I have a config like this:
```
var browserifyConfig = {
		watch: {
			files: browserifyFilesConfig,
			options: {
				// generate sourceMap, helps debug
				browserifyOptions: {
					debug: true
				},
				watch: true,
				keepAlive: true
			}
		}
	};
```

Somehow, when I change any file, the watch is never triggered. After I dived into it, it seems
```
bundle.on('error', onend);
bundle.on('end', onend);
function onend () { updating = false }
```
`onend` function is never triggered.
But if I add another event: `bundle.on('data', function() {});`, it fixed the bug. and onend is triggered, not sure why this happens, but it does help fix the problem.
