### PR TITLE
Update travis node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
+sudo: false
 language: node_js
 node_js:
-  - "0.8"
   - "0.10"
   - "0.12"
-  - "iojs"
-before_install:
-  - npm install -g npm@~1.4.6
+  - node


### PR DESCRIPTION
Drops node 0.8 and iojs. Adds node – the latest version. Turns on caching.