### PR TITLE
Enable outpipe for windows

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-var fs = require('fs');
 var path = require('path');
 var outpipe = require('outpipe');
 
@@ -34,9 +33,7 @@ bundle();
 
 function bundle () {
     var didError = false;
-    var outStream = process.platform === 'win32'
-        ? fs.createWriteStream(outfile)
-        : outpipe(outfile);
+    var outStream = outpipe(outfile);
 
     var wb = w.bundle();
     wb.on('error', function (err) {
@@ -49,7 +46,7 @@ function bundle () {
     outStream.on('error', function (err) {
         console.error(err);
     });
-    outStream.on('close', function () {
+    outStream.on('exit', function () {
         if (verbose && !didError) {
             console.error(bytes + ' bytes written to ' + outfile
                 + ' (' + (time / 1000).toFixed(2) + ' seconds)'

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "mkdirp": "~0.3.5",
     "split": "~0.3.0",
     "tape": "^2.12.3",
+    "uglify-js": "^2.5.0",
     "win-spawn": "^2.0.0"
   },
   "scripts": {

--- a/readme.markdown
+++ b/readme.markdown
@@ -51,8 +51,7 @@ Standard Options:
 
     This option is required. Write the browserify bundle to this file. If
     the file contains the operators `|` or `>`, it will be treated as a
-    shell command, and the output will be piped to it (not available on
-    Windows).
+    shell command, and the output will be piped to it.
 
   --verbose, -v                     [default: false]
 

--- a/test/bin_pipe.js
+++ b/test/bin_pipe.js
@@ -15,18 +15,13 @@ var files = {
 };
 
 mkdirp.sync(tmpdir);
-fs.writeFileSync(files.main, 'console.log(9+9+555)');
+fs.writeFileSync(files.main, 'console.log(num * 2)');
 
 test('bin with pipe', function (t) {
-    if (process.platform === 'win32') {
-        t.skip('not for windows');
-        t.end();
-        return;
-    }
     t.plan(4);
     var ps = spawn(cmd, [
         files.main,
-        '-o', 'sed "s/9+9+//" > ' + files.bundle,
+        '-o', 'uglifyjs - --enclose 11:num > ' + files.bundle,
         '-v'
     ]);
     var lineNum = 0;
@@ -35,14 +30,14 @@ test('bin with pipe', function (t) {
         if (lineNum === 1) {
             run(files.bundle, function (err, output) {
                 t.ifError(err);
-                t.equal(output, '555\n');
-                fs.writeFile(files.main, 'console.log(9+9+333)');
+                t.equal(output, '22\n');
+                fs.writeFile(files.main, 'console.log(num * 3)');
             });
         }
         else if (lineNum === 2) {
             run(files.bundle, function (err, output) {
                 t.ifError(err);
-                t.equal(output, '333\n');
+                t.equal(output, '33\n');
                 ps.kill();
             });
         }


### PR DESCRIPTION
Fixes #246.

Since outpipe v1.1.1, it will directly use `fs.createReadStream` when there aren't any shell operators. I have no idea how windows treats piping or redirection, but given that the simple case of outputting to a file works, I think it's safe to enable for windows users.

The tests pass on an "IE11 on Win 7" VM from [modern.ie](https://dev.modern.ie/tools/vms/) using node v4.2.1.