### PR TITLE
Allow for badly behaved plugins

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -38,13 +38,17 @@ function bundle () {
     var wb = w.bundle();
     
     w.pipeline.get('pack').once('readable', function() {
-        wb.pipe(writer);
+        if (!didError) {
+            wb.pipe(writer);
+        }
     });
     
     wb.on('error', function (err) {
         console.error(String(err));
-        didError = true;
-        writer.end('console.error(' + JSON.stringify(String(err)) + ');');
+        if (!didError) {
+            didError = true;
+            writer.end('console.error(' + JSON.stringify(String(err)) + ');');
+        }
     });
     
     writer.once('readable', function() {

--- a/test/bin_plugins_pipelining_multiple_errors.js
+++ b/test/bin_plugins_pipelining_multiple_errors.js
@@ -1,0 +1,56 @@
+var test = require('tape');
+var fs = require('fs');
+var path = require('path');
+var mkdirp = require('mkdirp');
+var spawn = require('win-spawn');
+var split = require('split');
+
+var cmd = path.resolve(__dirname, '../bin/cmd.js');
+var os = require('os');
+var tmpdir = path.join((os.tmpdir || os.tmpDir)(), 'watchify-' + Math.random());
+
+var files = {
+    main: path.join(tmpdir, 'main.js'),
+    plugin: path.join(tmpdir, 'plugin.js'),
+    bundle: path.join(tmpdir, 'bundle.js')
+};
+
+mkdirp.sync(tmpdir);
+fs.writeFileSync(files.plugin, [
+    'module.exports = function(b, opts) {',
+    '    b.on("file", function (file, id) {',
+    '        b.pipeline.emit("error", "bad boop");',
+    '        b.pipeline.emit("error", "bad boop");',
+    '    });',
+    '};',
+].join('\n'));
+fs.writeFileSync(files.main, 'boop\nbeep');
+
+test('bin plugins pipelining multiple errors', function (t) {
+    t.plan(4);
+    var ps = spawn(cmd, [
+        files.main,
+        '-p', files.plugin, '-v',
+        '-o', files.bundle
+    ]);
+    var lineNum = 0;
+    ps.stderr.pipe(split()).on('data', function (line) {
+        lineNum ++;
+        if (lineNum === 1) {
+            t.equal(line, 'bad boop');
+        }
+        if (lineNum === 2) {
+            t.equal(line, 'bad boop');
+            setTimeout(function() {
+              fs.writeFileSync(files.main, 'beep\nboop');
+            }, 1000);
+        }
+        if (lineNum === 3) {
+            t.equal(line, 'bad boop');
+        }
+        if (lineNum === 4) {
+            t.equal(line, 'bad boop');
+            ps.kill();
+        }
+    });
+});


### PR DESCRIPTION
Hi there,

Thanks for all your hard work, keep it up!

I have been fiddling around with the tsify plugin and noticed whenever i messed up my syntax badly watchify would crash.

Turns out plugins pipelining multiple errors makes bad things happen.

What would the expected behaviour of the plugin be in this case? Should it not be emitting multiple errors in the first place? Should it be pumping these errors out elsewhere? If so I'll have a go at fixing this over in tsify.

My node is weak so I apologise if the following is a complete travesty. Either way it has been an interesting learning exercise.

thanks again.