### PR TITLE
Add a "See Also" section to the readme

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -221,6 +221,12 @@ and [stackoverflow](http://stackoverflow.com/questions/26708205/webpack-watch-is
 Try the `--poll` flag
 and/or renaming the project's directory - that might help.
 
+# see also
+
+- [budo](https://www.npmjs.com/package/budo) – a simple development server built on watchify
+- [watchify-request](https://www.npmjs.com/package/watchify-request) – wraps a `watchify` instance to avoid stale bundles in HTTP requests
+- [watchify-middleware](https://www.npmjs.com/package/watchify-middleware) – similar to `watchify-request`, but includes some higher-level features
+
 # license
 
 MIT

--- a/readme.markdown
+++ b/readme.markdown
@@ -224,6 +224,7 @@ and/or renaming the project's directory - that might help.
 # see also
 
 - [budo](https://www.npmjs.com/package/budo) – a simple development server built on watchify
+- [errorify](https://www.npmjs.com/package/errorify) – a plugin to add error handling to watchify development
 - [watchify-request](https://www.npmjs.com/package/watchify-request) – wraps a `watchify` instance to avoid stale bundles in HTTP requests
 - [watchify-middleware](https://www.npmjs.com/package/watchify-middleware) – similar to `watchify-request`, but includes some higher-level features
 


### PR DESCRIPTION
I think there is a general perception that browserify/watchify is slow, [cumbersome to setup](https://github.com/gulpjs/gulp/blob/master/docs/recipes/browserify-with-globs.md), frequently serves stale/empty bundles, hides errors in terminal, produces ugly terminal logging, and introduces an otherwise poor developer experience compared to webpack/etc.

I don't feel this way at all, in fact I find browserify better than webpack on all of the above points, but only because I've built and worked on a lot of tools to help avoid these issues. I've added a "See Also" section to try and improve discovery with these tools.

I could take this PR a step further and push `budo` higher up in the readme. Of course I have some bias here, but in my experience most users do not need to interact with `watchify` CLI directly, and instead could use `budo` to provide a cleaner and faster development experience.