### PR TITLE
Fix documented default delay value

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -66,7 +66,7 @@ Standard Options:
 ```
 Advanced Options:
 
-  --delay                           [default: 600]
+  --delay                           [default: 100]
 
     Amount of time in milliseconds to wait before emitting an "update"
     event after a change.


### PR DESCRIPTION
Everywhere else (including the code) says the default `delay` value is `100`. This changes the one instance where the default is indicated as `600` to be `100`.