### PR TITLE
Watch files that are in cache at initialisation.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ function watchify (b, opts) {
     var changingDeps = {};
     var pending = false;
     var updating = false;
+    var transformCache = b._options.transformCache
     
     var wopts = {persistent: true};
     if (opts.ignoreWatch) {
@@ -90,7 +91,13 @@ function watchify (b, opts) {
     var ignoredFiles = {};
     
     b.on('transform', function (tr, mfile) {
+        if (transformCache && !transformCache[mfile]) {
+            transformCache[mfile] = [];
+        }
         tr.on('file', function (dep) {
+            if (transformCache) {
+                transformCache[mfile].push(dep);
+            }
             watchFile(mfile, dep);
         });
     });
@@ -163,6 +170,11 @@ function watchify (b, opts) {
 
     for (file in cache) {
         watchFile(file);
+        if (transformCache) {
+            for(dep in transformCache[file]) {
+                watchFile(file, transformCache[file][dep]);
+            };
+        }
     };
 
     return b;

--- a/index.js
+++ b/index.js
@@ -161,5 +161,9 @@ function watchify (b, opts) {
         return chokidar.watch(file, opts);
     };
 
+    for (file in cache) {
+        watchFile(file);
+    };
+
     return b;
 }


### PR DESCRIPTION
As per #306 I wanted to be able to pass an existing cache to watchify, since initial bundles can take considerable time. 

This works, and passes the local tests, it would be great to have this merged into the base, if you have more requirements for my end, I'll get to implementing them.