### PR TITLE
Also calling watchFile on collect, so that initially cached files get watched.

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ function watchify (b, opts) {
     function collect () {
         b.pipeline.get('deps').push(through.obj(function(row, enc, next) {
             var file = row.expose ? b._expose[row.id] : row.file;
+            watchFile(file);
             cache[file] = {
                 source: row.source,
                 deps: xtend(row.deps)


### PR DESCRIPTION
Fixes issue #306.

Calling `watchFile` in `collect` should not be a problem because 1) `watchFile` is smart enough to not add a file watcher if the given file is already watched and 2) `collect` is not executed often enough to impose a problem for the extra basic operations.

I noticed no performance difference watching my projects, and the test suite is running as fast as before:

before: `npm test  5.63s user 0.88s system 25% cpu 25.075 total`
after: `npm test  5.60s user 0.87s system 25% cpu 25.032 total`