### PR TITLE
Escaping spaces / parentheses in file paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,6 +158,7 @@ function watchify (b, opts) {
     };
     
     b._watcher = function (file, opts) {
+        file = file.replace(/\s|\(|\)/g, (e) => { return `\\${e}` });
         return chokidar.watch(file, opts);
     };
 


### PR DESCRIPTION
I don't think this is the most elegant solution, but I'm not too familiar with node. I was running into the problem where watchify was breaking for the following path.


`/users/rickyc/Example (GitHub)/something`

This was a quick monkey patch to fix the issue. After tracing it this far, I noticed that this could probably be fixed in `chokidar` as well and going even further into `fs`.

Thoughts as to how I can clean this logic up?