### PR TITLE
Include Time in Verbose Message

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -59,7 +59,8 @@ function bundle () {
         outStream.on('exit', function () {
             if (verbose && !didError) {
                 console.error(bytes + ' bytes written to ' + outfile
-                    + ' (' + (time / 1000).toFixed(2) + ' seconds)'
+                    + ' (' + (time / 1000).toFixed(2) + ' seconds) at '
+                    + new Date().toLocaleTimeString()
                 );
             }
         });

--- a/readme.markdown
+++ b/readme.markdown
@@ -31,12 +31,12 @@ You can use `-v` to get more verbose output to show when a file was written and 
 
 ```
 $ watchify browser.js -d -o static/bundle.js -v
-610598 bytes written to static/bundle.js (0.23 seconds)
-610606 bytes written to static/bundle.js (0.10 seconds)
-610597 bytes written to static/bundle.js (0.14 seconds)
-610606 bytes written to static/bundle.js (0.08 seconds)
-610597 bytes written to static/bundle.js (0.08 seconds)
-610597 bytes written to static/bundle.js (0.19 seconds)
+610598 bytes written to static/bundle.js (0.23 seconds) at 8:31:25 PM
+610606 bytes written to static/bundle.js (0.10 seconds) at 8:45:59 PM
+610597 bytes written to static/bundle.js (0.14 seconds) at 8:46:02 PM
+610606 bytes written to static/bundle.js (0.08 seconds) at 8:50:13 PM
+610597 bytes written to static/bundle.js (0.08 seconds) at 8:58:16 PM
+610597 bytes written to static/bundle.js (0.19 seconds) at 9:10:45 PM
 ```
 
 # usage


### PR DESCRIPTION
See #332, The documentation does say -v logs when the file was written and I feel it would be helpful to see actual timestamps. Not sure if this is the best format for the timestamp, discuss if you feel inclined to a different format.
