### PR TITLE
Added disableGlobbing option, added in Chokidar 1.7.0

### DIFF
--- a/bin/args.js
+++ b/bin/args.js
@@ -11,6 +11,10 @@ module.exports = function (args) {
     if (ignoreWatch) {
         opts.ignoreWatch = ignoreWatch;
     }
+    var disableGlobbing = defined(b.argv['disable-globbing']);
+    if (disableGlobbing) {
+        opts.disableGlobbing = true;
+    }
 
     return watchify(b, xtend(opts, b.argv));
 };

--- a/index.js
+++ b/index.js
@@ -30,6 +30,9 @@ function watchify (b, opts) {
             ? opts.poll
             : undefined;
     }
+    if (opts.disableGlobbing) {
+        wopts.disableGlobbing = true;
+    }
 
     if (cache) {
         b.on('reset', collect);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "anymatch": "^1.3.0",
     "browserify": "^14.0.0",
-    "chokidar": "^1.0.0",
+    "chokidar": "^1.7.0",
     "defined": "^1.0.0",
     "outpipe": "^1.1.0",
     "through2": "^2.0.0",

--- a/readme.markdown
+++ b/readme.markdown
@@ -80,6 +80,11 @@ Advanced Options:
 
     Use polling to monitor for changes. Omitting the interval will default
     to 100ms. This option is useful if you're watching an NFS volume.
+
+  --disable-globbing                [default: false]
+
+    If set to `true` then entry files are treated as literal path names, 
+    even if they look like globs.
 ```
 
 # methods
@@ -166,6 +171,9 @@ b.plugin(bundle, {
   poll: false
 });
 ```
+
+`opts.disableGlobbing` treats entry files as literal path names, even if they look like globs. 
+See also Chokidar's [documentation](https://github.com/paulmillr/chokidar#path-filtering).
 
 ## b.close()
 


### PR DESCRIPTION
In Chokidar 1.7.0 a new option [has been added](https://github.com/paulmillr/chokidar/pull/535) to bypass [a long lasting issue](https://github.com/paulmillr/chokidar/issues/300) about directories with name including glob characters, like parenthesis.

This PR adds a new `disableGlobbing` option on watchify, and passes it to Chokidar. I also added `--disable-globbing` to the command line interface, although its short version it's missing because `--dg` is already a completely unrelated browserify option.