### PR TITLE
Avoid deprecation in upcoming version of node

### DIFF
--- a/test/bin.js
+++ b/test/bin.js
@@ -27,7 +27,7 @@ test('bin', function (t) {
             run(files.bundle, function (err, output) {
                 t.ifError(err);
                 t.equal(output, '555\n');
-                fs.writeFile(files.main, 'console.log(333)');
+                fs.writeFile(files.main, 'console.log(333)', function(err) {});
             })
         }
         else if (lineNum === 2) {


### PR DESCRIPTION
```
 fs.js:101
     throw new (lazyErrors().TypeError)('ERR_INVALID_CALLBACK');
     ^
 TypeError [ERR_INVALID_CALLBACK]: callback must be a function
     at maybeCallback (fs.js:101:11)
     at Object.fs.writeFile (fs.js:1228:14)
     at /home/iojs/build/workspace/citgm-smoker/nodes/debian8-64/citgm_tmp/39252caf-563e-48c1-996a-8955580a49e0/watchify/test/bin.js:30:20
     at Socket.<anonymous> (/home/iojs/build/workspace/citgm-smoker/nodes/debian8-64/citgm_tmp/39252caf-563e-48c1-996a-8955580a49e0/watchify/test/bin.js:48:9)
     at emitNone (events.js:110:20)
     at Socket.emit (events.js:207:7)
     at endReadableNT (_stream_readable.js:996:12)
     at _combinedTickCallback (internal/process/next_tick.js:102:11)
     at process._tickCallback (internal/process/next_tick.js:161:9)
```

Similar changes may/may not need to be made elsewhere, this was at least the first instance I noticed when running this project's tests in node's citgm.