### PR TITLE
patch update chokidar, swap deprecated win-spawn with cross-spawn

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "anymatch": "^3.1.0",
     "browserify": "^17.0.0",
-    "chokidar": "^3.4.0",
+    "chokidar": "^3.5.2",
     "defined": "^1.0.0",
     "outpipe": "^1.1.0",
     "through2": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "split": "^1.0.0",
     "tape": "^5.1.1",
     "uglify-js": "^2.5.0",
-    "win-spawn": "^2.0.0"
+    "cross-spawn": "^7.0.3"
   },
   "scripts": {
     "test": "tape test/*.js"

--- a/test/bin.js
+++ b/test/bin.js
@@ -2,7 +2,7 @@ var test = require('tape');
 var fs = require('fs');
 var path = require('path');
 var mkdirp = require('mkdirp');
-var spawn = require('win-spawn');
+var spawn = require('cross-spawn');
 var split = require('split');
 
 var cmd = path.resolve(__dirname, '../bin/cmd.js');

--- a/test/bin_brfs.js
+++ b/test/bin_brfs.js
@@ -2,7 +2,7 @@ var test = require('tape');
 var fs = require('fs');
 var path = require('path');
 var mkdirp = require('mkdirp');
-var spawn = require('win-spawn');
+var spawn = require('cross-spawn');
 var split = require('split');
 
 var cmd = path.resolve(__dirname, '../bin/cmd.js');

--- a/test/bin_ignore_watch.js
+++ b/test/bin_ignore_watch.js
@@ -2,7 +2,7 @@ var test = require('tape');
 var fs = require('fs');
 var path = require('path');
 var mkdirp = require('mkdirp');
-var spawn = require('win-spawn');
+var spawn = require('cross-spawn');
 var split = require('split');
 
 var cmd = path.resolve(__dirname, '../bin/cmd.js');

--- a/test/bin_ignore_watch_default.js
+++ b/test/bin_ignore_watch_default.js
@@ -2,7 +2,7 @@ var test = require('tape');
 var fs = require('fs');
 var path = require('path');
 var mkdirp = require('mkdirp');
-var spawn = require('win-spawn');
+var spawn = require('cross-spawn');
 var split = require('split');
 
 var cmd = path.resolve(__dirname, '../bin/cmd.js');

--- a/test/bin_ignore_watch_multiple.js
+++ b/test/bin_ignore_watch_multiple.js
@@ -2,7 +2,7 @@ var test = require('tape');
 var fs = require('fs');
 var path = require('path');
 var mkdirp = require('mkdirp');
-var spawn = require('win-spawn');
+var spawn = require('cross-spawn');
 var split = require('split');
 
 var cmd = path.resolve(__dirname, '../bin/cmd.js');

--- a/test/bin_pipe.js
+++ b/test/bin_pipe.js
@@ -2,7 +2,7 @@ var test = require('tape');
 var fs = require('fs');
 var path = require('path');
 var mkdirp = require('mkdirp');
-var spawn = require('win-spawn');
+var spawn = require('cross-spawn');
 var split = require('split');
 
 var cmd = path.resolve(__dirname, '../bin/cmd.js');

--- a/test/bin_plugins_pipelining_multiple_errors.js
+++ b/test/bin_plugins_pipelining_multiple_errors.js
@@ -2,7 +2,7 @@ var test = require('tape');
 var fs = require('fs');
 var path = require('path');
 var mkdirp = require('mkdirp');
-var spawn = require('win-spawn');
+var spawn = require('cross-spawn');
 var split = require('split');
 
 var cmd = path.resolve(__dirname, '../bin/cmd.js');

--- a/test/bin_standalone.js
+++ b/test/bin_standalone.js
@@ -2,7 +2,7 @@ var test = require('tape');
 var fs = require('fs');
 var path = require('path');
 var mkdirp = require('mkdirp');
-var spawn = require('win-spawn');
+var spawn = require('cross-spawn');
 var split = require('split');
 
 var cmd = path.resolve(__dirname, '../bin/cmd.js');

--- a/test/many.js
+++ b/test/many.js
@@ -2,7 +2,7 @@ var test = require('tape');
 var fs = require('fs');
 var path = require('path');
 var mkdirp = require('mkdirp');
-var spawn = require('win-spawn');
+var spawn = require('cross-spawn');
 var split = require('split');
 
 var cmd = path.resolve(__dirname, '../bin/cmd.js');
@@ -66,11 +66,11 @@ test('many edits', function (t) {
     var lineNum = 0;
     ps.stderr.pipe(split()).on('data', function (line) {
         if (line.length === 0) return;
-        
+
         run(files.bundle, function (err, output) {
             t.ifError(err);
             t.equal(output, expected.shift());
-            
+
             (function next () {
                 if (edits.length === 0) return;
                 var edit = edits.shift();
@@ -83,7 +83,7 @@ test('many edits', function (t) {
             })();
         })
     });
-    
+
     t.on('end', function () {
         ps.kill();
     });

--- a/test/many_immediate.js
+++ b/test/many_immediate.js
@@ -2,7 +2,7 @@ var test = require('tape');
 var fs = require('fs');
 var path = require('path');
 var mkdirp = require('mkdirp');
-var spawn = require('win-spawn');
+var spawn = require('cross-spawn');
 var split = require('split');
 
 var cmd = path.resolve(__dirname, '../bin/cmd.js');
@@ -66,11 +66,11 @@ test('many immediate', function (t) {
     var lineNum = 0;
     ps.stderr.pipe(split()).on('data', function (line) {
         if (line.length === 0) return;
-        
+
         run(files.bundle, function (err, output) {
             t.ifError(err);
             t.equal(output, expected.shift());
-            
+
             (function next () {
                 if (edits.length === 0) return;
                 var edit = edits.shift();
@@ -81,7 +81,7 @@ test('many immediate', function (t) {
             })();
         })
     });
-    
+
     t.on('end', function () {
         ps.kill();
     });


### PR DESCRIPTION
Trying to get rid of some deprecation and vulnerability warnings
Fix advisory 1751 by updating chokidar
Fix deprecation warning about win-spawn (dev-dependencies only)